### PR TITLE
Windows compat - catching the error when xcrun fails (on Windows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 lib
 .nyc_output
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "husky": "^9.1.7",
         "mocha": "^11.1.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.8.2"
+        "typescript": "^5.8.3"
       },
       "engines": {
         "node": ">=18"

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,11 +60,24 @@ export const createMcpServer = (): McpServer => {
 		"List all available devices. This includes both physical devices and simulators. If there is more than one device returned, you need to let the user select one of them.",
 		{},
 		async ({}) => {
-			const iosManager = new IosManager();
-			const devices = await simulatorManager.listBootedSimulators();
-			const simulatorNames = devices.map(d => d.name);
+			let simulatorNames: any[] = [];
+			let iosDevices: any[] = [];
 			const androidDevices = getConnectedDevices();
-			const iosDevices = await iosManager.listDevices();
+
+			try {
+				const devices = await simulatorManager.listBootedSimulators();
+				simulatorNames = devices.map(d => d.name);
+			} catch (err: any) {
+				trace(`Error listing iOS simulators: ${String(err)}`);
+			}
+
+			try {
+				const iosManager = new IosManager();
+				iosDevices = await iosManager.listDevices();
+			} catch (err: any) {
+				trace(`Error listing iOS devices: ${String(err)}`);
+			}
+
 			return `Found these iOS simulators: [${simulatorNames.join(".")}], iOS devices: [${iosDevices.join(",")}] and Android devices: [${androidDevices.join(",")}]`;
 		}
 	);

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,23 +60,32 @@ export const createMcpServer = (): McpServer => {
 		"List all available devices. This includes both physical devices and simulators. If there is more than one device returned, you need to let the user select one of them.",
 		{},
 		async ({}) => {
+			trace("========== DEVICE DETECTION STARTED ==========");
 			let simulatorNames: any[] = [];
 			let iosDevices: any[] = [];
-			const androidDevices = getConnectedDevices();
 
+			trace("Getting Android devices...");
+			const androidDevices = getConnectedDevices();
+			trace(`Found Android devices: [${androidDevices.join(", ")}]`);
+
+			trace("Getting iOS simulators...");
 			try {
 				const devices = await simulatorManager.listBootedSimulators();
 				simulatorNames = devices.map(d => d.name);
+				trace(`Found iOS simulators: [${simulatorNames.join(", ")}]`);
 			} catch (err: any) {
 				trace(`Error listing iOS simulators: ${String(err)}`);
 			}
 
+			trace("Getting iOS devices...");
 			try {
 				const iosManager = new IosManager();
 				iosDevices = await iosManager.listDevices();
+				trace(`Found iOS devices: [${iosDevices.join(", ")}]`);
 			} catch (err: any) {
 				trace(`Error listing iOS devices: ${String(err)}`);
 			}
+			trace("========== DEVICE DETECTION COMPLETED ==========");
 
 			return `Found these iOS simulators: [${simulatorNames.join(".")}], iOS devices: [${iosDevices.join(",")}] and Android devices: [${androidDevices.join(",")}]`;
 		}


### PR DESCRIPTION
I might be over-logging here, so I can calm that down. I'm running from a Windows box, and all calls to XC tools failed. This PR is just to make that non-fatal. I'm a Typescript newb, so any feedback/advice is welcome. I can't run this on my work laptop (AI policies) to test it on mac. Again--feedback is welcome.