### PR TITLE
fix: handle missing element label by using element name as fallback

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -176,7 +176,7 @@ export const createMcpServer = (): McpServer => {
 				const y = Number((element.rect.y + element.rect.height / 2)).toFixed(3);
 
 				return {
-					text: element.label,
+					text: element.label || element.name,
 					coordinates: { x, y }
 				};
 			});


### PR DESCRIPTION
In the case of Android apps, each UI element rarely has a label set.

Therefore, as described below, if display text exists, it is exposed as text.

https://github.com/mobile-next/mobile-mcp?tab=readme-ov-file#mobile_list_elements_on_screen

> Description: List elements on screen and their coordinates, with display text or accessibility label.

close #32

