### PR TITLE
Add AndroidTV specific tools 'navigate to item with label' and 'press dpad'

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -354,12 +354,15 @@ export class AndroidRobot implements Robot {
 	/**
 	 * Get the dpad direction based on the target coordinates.
 	 *
-	 * @param targetX - The target X coordinate.
-	 * @param targetY - The target Y coordinate.
+	 * @param focusedRect - The focused element.
+	 * @param targetX - The target x coordinate.
+	 * @param targetY - The target y coordinate.
+	 *
 	 * @returns The dpad direction or null if no dpad direction is needed.
 	 */
 	private getDpadDirection(focusedRect: ScreenElementRect, targetX: number, targetY: number): DpadButton | null {
-		// If within bounds then no dpad direction is needed
+		// If target matches the focused element's coordinate, it means that we are already on the target.
+		// No need to press any dpad button further.
 		if (focusedRect.x === targetX && focusedRect.y === targetY) {
 			return null;
 		}
@@ -384,7 +387,7 @@ export class AndroidRobot implements Robot {
 
 	private requireAndroidTv() {
 		if (this.deviceType !== "tv") {
-			throw new ActionableError("No device selected. Use the mobile_use_device tool to select a device.");
+			throw new ActionableError("This method is only supported on Android TV devices. Let the user about it and stop executing further commands.");
 		}
 	}
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,6 +62,13 @@ export const createMcpServer = (): McpServer => {
 		}
 	};
 
+	const requireTvRobot = () => {
+		requireRobot();
+		if (!(robot instanceof AndroidRobot && robot.deviceType === "tv")) {
+			throw new ActionableError("This tool is only supported on Android TV devices. Let user know about this.");
+		}
+	};
+
 	tool(
 		"mobile_list_available_devices",
 		"List all available devices. This includes both physical devices and simulators. If there is more than one device returned, you need to let the user select one of them.",
@@ -96,7 +103,9 @@ export const createMcpServer = (): McpServer => {
 					break;
 			}
 
-			return `Selected device: ${device} (${deviceType})`;
+			const isAndroidTv = (robot instanceof AndroidRobot && robot.deviceType === "tv");
+
+			return `Selected device: ${device} (${deviceType}${isAndroidTv ? ", (Android TV)" : ""})`;
 		}
 	);
 
@@ -306,6 +315,34 @@ export const createMcpServer = (): McpServer => {
 			requireRobot();
 			const orientation = await robot!.getOrientation();
 			return `Current device orientation is ${orientation}`;
+		}
+	);
+
+	tool(
+		"tv_dpad_navigate_to_item_with_label",
+		"Navigate to an item on screen with a specific label using D-pad. This is specifically for TV devices which depend on D-pad based traversal.",
+		{
+			label: z.string().describe("The label of the item to navigate to"),
+		},
+		async ({ label }) => {
+			requireTvRobot();
+			(robot as AndroidRobot).navigateToItemWithLabel(label);
+
+			return `Navigated with D-pad to item with label: ${label}`;
+		}
+	);
+
+	tool(
+		"tv_dpad_press_button",
+		"Press a button on the D-pad. This is specifically for TV Devices which depend on D-pad.",
+		{
+			button: z.string().describe("The D-pad button to press. Supported buttons: DPAD_CENTER (center), DPAD_UP(up), DPAD_DOWN(down), DPAD_LEFT(left), DPAD_RIGHT(right)"),
+		},
+		async ({ button }) => {
+			requireTvRobot();
+			(robot as AndroidRobot).pressDpad(button);
+
+			return `Pressed D-pad button: ${button}`;
 		}
 	);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -65,7 +65,7 @@ export const createMcpServer = (): McpServer => {
 	const requireTvRobot = () => {
 		requireRobot();
 		if (!(robot instanceof AndroidRobot && robot.deviceType === "tv")) {
-			throw new ActionableError("This tool is only supported on Android TV devices. Let user know about this.");
+			throw new ActionableError("This tool is only supported on Android TV devices. Let user know about this and stop executing further commands.");
 		}
 	};
 
@@ -105,7 +105,7 @@ export const createMcpServer = (): McpServer => {
 
 			const isAndroidTv = (robot instanceof AndroidRobot && robot.deviceType === "tv");
 
-			return `Selected device: ${device} (${deviceType}${isAndroidTv ? ", (Android TV)" : ""})`;
+			return `Selected device: ${device} (${deviceType}).${isAndroidTv ? " This is an AndroidTV. Use tv specific tools for navigation and selecting" : ""}`;
 		}
 	);
 


### PR DESCRIPTION
## What
Add two specific tools for AndroidTV (should also be compatible with Amazon FireTV). 
- navigate to item with given label (text, content-description or hint). 
  - `tv_dpad_navigate_to_item_with_label`
  - this label is extracted by the `mobile_list_elements_on_screen` tool
- press dpad button
  - `tv_dpad_press_button`
  - supported directions：up, down, left, right and center

> [!Warning]
> I'm not completely familiar with tvOS. So currently added support only for AndroidTV.

## Why
Navigating or selecting element on AndroidTV devices, can only be performed using the D-pad. 
One needs to first move focus to the item to be tapped using D-Pad based navigation and then tap.

## How
I've added code comments 🙇‍♂️ 

## Screenshot
Working sample for `tv_dpad_navigate_to_item_with_label`  tool

https://github.com/user-attachments/assets/37f4156c-7119-4c09-986c-d80228441342

