### PR TITLE
fix: Normalize line endings in Android screenshots for Windows compatibility

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -142,12 +142,7 @@ export class AndroidRobot implements Robot {
 	}
 
 	public async getScreenshot(): Promise<Buffer> {
-		const rawScreenshot = this.adb("shell", "screencap", "-p");
-		return this.normalizeLineEndings(rawScreenshot);
-	}
-
-	private normalizeLineEndings(buffer: Buffer): Buffer {
-		return Buffer.from(buffer.toString("binary").replace(/\r\n/g, "\n"), "binary");
+		return this.adb("exec-out", "screencap", "-p");
 	}
 
 	private collectElements(node: UiAutomatorXmlNode): ScreenElement[] {

--- a/src/android.ts
+++ b/src/android.ts
@@ -142,7 +142,12 @@ export class AndroidRobot implements Robot {
 	}
 
 	public async getScreenshot(): Promise<Buffer> {
-		return this.adb("shell", "screencap", "-p");
+		const rawScreenshot = this.adb("shell", "screencap", "-p");
+		return this.normalizeLineEndings(rawScreenshot);
+	}
+
+	private normalizeLineEndings(buffer: Buffer): Buffer {
+		return Buffer.from(buffer.toString("binary").replace(/\r\n/g, "\n"), "binary");
 	}
 
 	private collectElements(node: UiAutomatorXmlNode): ScreenElement[] {


### PR DESCRIPTION
## Problem Description
When using MCP's screenshot functionality on Windows, we encountered a "Not a valid PNG file" error. After investigation, we found that the PNG signature was invalid:


## Debugging Process
1. **Initial Error Analysis**
   - The error message showed a mismatch in PNG signature bytes
   - The actual signature contained an extra `0d` (CR) byte
   - This pattern suggested a Windows-style line ending issue (CRLF vs LF)

2. **Root Cause Investigation**
   - We examined the raw buffer from `adb screencap -p`
   - Using hex dump, we confirmed that Windows was converting all `0a` (LF) to `0d 0a` (CRLF)
   - This conversion was happening at the system level when Windows processes the adb output

3. **Solution Development**
   - We added a `normalizeLineEndings` method to handle the conversion
   - The method converts all `\r\n` (CRLF) back to `\n` (LF)
   - We use `Buffer.from()` with "binary" encoding to ensure proper byte handling

## Changes Made
- Added `normalizeLineEndings` method to handle Windows line ending conversion
- Updated `getScreenshot()` to use the new normalization method
- Ensured proper binary buffer handling throughout the process

## Testing
- Successfully tested on Windows environment

## Related Issues
- Fixes #40 