### PR TITLE
feat: Add identifier property to ScreenElement

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -18,6 +18,7 @@ interface UiAutomatorXmlNode {
 	hint?: string;
 	focused?: string;
 	"content-desc"?: string;
+	"resource-id"?: string;
 }
 
 interface UiAutomatorXml {
@@ -169,6 +170,11 @@ export class AndroidRobot implements Robot {
 			if (node.focused === "true") {
 				// only provide it if it's true, otherwise don't confuse llm
 				element.focused = true;
+			}
+
+			const resourceId = node["resource-id"];
+			if (resourceId !== null && resourceId !== "") {
+				element.identifier = resourceId;
 			}
 
 			if (element.rect.width > 0 && element.rect.height > 0) {

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -29,6 +29,7 @@ export interface ScreenElement {
 	text?: string;
 	name?: string;
 	value?: string;
+	identifier?: string;
 	rect: ScreenElementRect;
 
 	// currently only on android tv

--- a/src/server.ts
+++ b/src/server.ts
@@ -219,6 +219,7 @@ export const createMcpServer = (): McpServer => {
 					label: element.label,
 					name: element.name,
 					value: element.value,
+					identifier: element.identifier,
 					coordinates: {
 						x: element.rect.x,
 						y: element.rect.y,

--- a/src/webdriver-agent.ts
+++ b/src/webdriver-agent.ts
@@ -163,12 +163,13 @@ export class WebDriverAgent {
 
 		if (acceptedTypes.includes(source.type)) {
 			if (source.isVisible === "1" && this.isVisible(source.rect)) {
-				if (source.label !== null || source.name !== null) {
+				if (source.label !== null || source.name !== null || source.rawIdentifier !== null) {
 					output.push({
 						type: source.type,
 						label: source.label,
 						name: source.name,
 						value: source.value,
+						identifier: source.rawIdentifier,
 						rect: {
 							x: source.rect.x,
 							y: source.rect.y,


### PR DESCRIPTION
Add the accessibilityIdentifier in iOS and the id that can be specified in Compose's testTag in Android to the ScreenElement as the identifier property.

This is useful when there are multiple UI elements with the same name, or to identify image UI elements that have no name.