### PR TITLE
docs: Remove duplicate setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,10 @@ Setup our MCP with Cline, Cursor, Claude, VS Code, Github Copilot:
 [Cline:](https://docs.cline.bot/mcp/configuring-mcp-servers) To setup Cline, just add the json above to your MCP settings file. 
 [More in our wiki](https://github.com/mobile-next/mobile-mcp/wiki/Cline) 
 
-
-```
-claude mcp add mobile -- npx -y @mobilenext/mobile-mcp@latest ⁠
-```
-
 [Claude Code:](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview)
 
 ```
-claude mcp add mobile -- npx -y @mobilenext/mobile-mcp@latest ⁠
+claude mcp add mobile -- npx -y @mobilenext/mobile-mcp@latest
 ```
 
 [Read more in our wiki](https://github.com/mobile-next/mobile-mcp/wiki)! 🚀


### PR DESCRIPTION
## what

- Remove duplicate setup instruction introduced in https://github.com/mobile-next/mobile-mcp/commit/e0e3ed548e879bac7fa420411a6c2fbe2f617299
- Fix trailing whitespace in installation commands 