### PR TITLE
Improved swipe support

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -117,7 +117,7 @@ export class AndroidRobot implements Robot {
 			.map(line => line.split(/\s+/)[8]); // get process name
 	}
 
-		public async swipe(direction: SwipeDirection): Promise<void> {
+	public async swipe(direction: SwipeDirection): Promise<void> {
 		const screenSize = await this.getScreenSize();
 		const centerX = screenSize.width >> 1;
 

--- a/src/android.ts
+++ b/src/android.ts
@@ -117,10 +117,9 @@ export class AndroidRobot implements Robot {
 			.map(line => line.split(/\s+/)[8]); // get process name
 	}
 
-	public async swipe(direction: SwipeDirection): Promise<void> {
+		public async swipe(direction: SwipeDirection): Promise<void> {
 		const screenSize = await this.getScreenSize();
 		const centerX = screenSize.width >> 1;
-		// const centerY = screenSize[1] >> 1;
 
 		let x0: number, y0: number, x1: number, y1: number;
 
@@ -134,6 +133,55 @@ export class AndroidRobot implements Robot {
 				x0 = x1 = centerX;
 				y0 = Math.floor(screenSize.height * 0.20);
 				y1 = Math.floor(screenSize.height * 0.80);
+				break;
+			case "left":
+				x0 = Math.floor(screenSize.width * 0.80);
+				x1 = Math.floor(screenSize.width * 0.20);
+				y0 = y1 = Math.floor(screenSize.height * 0.50);
+				break;
+			case "right":
+				x0 = Math.floor(screenSize.width * 0.20);
+				x1 = Math.floor(screenSize.width * 0.80);
+				y0 = y1 = Math.floor(screenSize.height * 0.50);
+				break;
+			default:
+				throw new ActionableError(`Swipe direction "${direction}" is not supported`);
+		}
+
+		this.adb("shell", "input", "swipe", `${x0}`, `${y0}`, `${x1}`, `${y1}`, "1000");
+	}
+
+	public async swipeFromCoordinate(x: number, y: number, direction: SwipeDirection, distance?: number): Promise<void> {
+		const screenSize = await this.getScreenSize();
+
+		let x0: number, y0: number, x1: number, y1: number;
+
+		// Use provided distance or default to 30% of screen dimension
+		const defaultDistanceY = Math.floor(screenSize.height * 0.3);
+		const defaultDistanceX = Math.floor(screenSize.width * 0.3);
+		const swipeDistanceY = distance || defaultDistanceY;
+		const swipeDistanceX = distance || defaultDistanceX;
+
+		switch (direction) {
+			case "up":
+				x0 = x1 = x;
+				y0 = y;
+				y1 = Math.max(0, y - swipeDistanceY);
+				break;
+			case "down":
+				x0 = x1 = x;
+				y0 = y;
+				y1 = Math.min(screenSize.height, y + swipeDistanceY);
+				break;
+			case "left":
+				x0 = x;
+				x1 = Math.max(0, x - swipeDistanceX);
+				y0 = y1 = y;
+				break;
+			case "right":
+				x0 = x;
+				x1 = Math.min(screenSize.width, x + swipeDistanceX);
+				y0 = y1 = y;
 				break;
 			default:
 				throw new ActionableError(`Swipe direction "${direction}" is not supported`);

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -121,6 +121,11 @@ export class IosRobot implements Robot {
 		await wda.swipe(direction);
 	}
 
+	public async swipeFromCoordinate(x: number, y: number, direction: SwipeDirection, distance?: number): Promise<void> {
+		const wda = await this.wda();
+		await wda.swipeFromCoordinate(x, y, direction, distance);
+	}
+
 	public async listApps(): Promise<InstalledApp[]> {
 		await this.assertTunnelRunning();
 

--- a/src/iphone-simulator.ts
+++ b/src/iphone-simulator.ts
@@ -168,9 +168,14 @@ export class Simctl implements Robot {
 		return wda.sendKeys(keys);
 	}
 
-	public async swipe(direction: SwipeDirection) {
+	public async swipe(direction: SwipeDirection): Promise<void> {
 		const wda = await this.wda();
 		return wda.swipe(direction);
+	}
+
+	public async swipeFromCoordinate(x: number, y: number, direction: SwipeDirection, distance?: number): Promise<void> {
+		const wda = await this.wda();
+		return wda.swipeFromCoordinate(x, y, direction, distance);
 	}
 
 	public async tap(x: number, y: number) {

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -56,6 +56,11 @@ export interface Robot {
 	swipe(direction: SwipeDirection): Promise<void>;
 
 	/**
+	 * Swipe from a specific coordinate in a direction.
+	 */
+	swipeFromCoordinate(x: number, y: number, direction: SwipeDirection, distance?: number): Promise<void>;
+
+	/**
 	 * Get a screenshot of the screen. Returns a Buffer that contains
 	 * a PNG image of the screen. Will be same dimensions as getScreenSize().
 	 */

--- a/src/server.ts
+++ b/src/server.ts
@@ -269,12 +269,24 @@ export const createMcpServer = (): McpServer => {
 		"swipe_on_screen",
 		"Swipe on the screen",
 		{
-			direction: z.enum(["up", "down"]).describe("The direction to swipe"),
+			direction: z.enum(["up", "down", "left", "right"]).describe("The direction to swipe"),
+			x: z.number().optional().describe("The x coordinate to start the swipe from, in pixels. If not provided, uses center of screen"),
+			y: z.number().optional().describe("The y coordinate to start the swipe from, in pixels. If not provided, uses center of screen"),
+			distance: z.number().optional().describe("The distance to swipe in pixels. Defaults to 400 pixels for iOS or 30% of screen dimension for Android"),
 		},
-		async ({ direction }) => {
+		async ({ direction, x, y, distance }) => {
 			requireRobot();
-			await robot!.swipe(direction);
-			return `Swiped ${direction} on screen`;
+
+			if (x !== undefined && y !== undefined) {
+				// Use coordinate-based swipe
+				await robot!.swipeFromCoordinate(x, y, direction, distance);
+				const distanceText = distance ? ` ${distance} pixels` : "";
+				return `Swiped ${direction}${distanceText} from coordinates: ${x}, ${y}`;
+			} else {
+				// Use center-based swipe
+				await robot!.swipe(direction);
+				return `Swiped ${direction} on screen`;
+			}
 		}
 	);
 


### PR DESCRIPTION
Introduces three new parameters to the swipe_screen mcp tool. Adds left and right swiping.

- `direction`: `left`, `right`, `up`, or `down`
- `distance`: Distance to swipe in pixels. Default is 30% of screen width/height.
- `x`: The x-coordinate of the position to start the swipe gesture
- `y`: The y-coordinate of the position to start the swipe gesture

### Testplan

- [x] iOS default swipe up+down works like before
- [ ] Android default swipe up+down works like before
- [x] iOS swipe left+right works
- [ ] Android swipe left+right works
- [x] iOS swipe from coords works
- [ ] Android swipe from coords works

iOS video >> https://jumpshare.com/s/Z9OnXmYNivSsVeRY58pg