### PR TITLE
Fix: MCP error -32602: Invalid arguments Tool Error (for WindSurf)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,8 @@ export const createMcpServer = (): McpServer => {
 		},
 	});
 
+	const noParams = z.object({});
+
 	const tool = (name: string, description: string, paramsSchema: ZodRawShape, cb: (args: z.objectOutputType<ZodRawShape, ZodTypeAny>) => Promise<string>) => {
 		const wrappedCb = async (args: ZodRawShape): Promise<CallToolResult> => {
 			try {
@@ -84,7 +86,9 @@ export const createMcpServer = (): McpServer => {
 	tool(
 		"mobile_list_available_devices",
 		"List all available devices. This includes both physical devices and simulators. If there is more than one device returned, you need to let the user select one of them.",
-		{},
+		{
+			noParams
+		},
 		async ({}) => {
 			const iosManager = new IosManager();
 			const androidManager = new AndroidDeviceManager();
@@ -144,7 +148,9 @@ export const createMcpServer = (): McpServer => {
 	tool(
 		"mobile_list_apps",
 		"List all the installed apps on the device",
-		{},
+		{
+			noParams
+		},
 		async ({}) => {
 			requireRobot();
 			const result = await robot!.listApps();
@@ -181,7 +187,9 @@ export const createMcpServer = (): McpServer => {
 	tool(
 		"mobile_get_screen_size",
 		"Get the screen size of the mobile device in pixels",
-		{},
+		{
+			noParams
+		},
 		async ({}) => {
 			requireRobot();
 			const screenSize = await robot!.getScreenSize();
@@ -207,6 +215,7 @@ export const createMcpServer = (): McpServer => {
 		"mobile_list_elements_on_screen",
 		"List elements on screen and their coordinates, with display text or accessibility label. Do not cache this result.",
 		{
+			noParams
 		},
 		async ({}) => {
 			requireRobot();
@@ -300,7 +309,9 @@ export const createMcpServer = (): McpServer => {
 	server.tool(
 		"mobile_take_screenshot",
 		"Take a screenshot of the mobile device. Use this to understand what's on screen, if you need to press an element that is available through view hierarchy then you must list elements on screen instead. Do not cache this result.",
-		{},
+		{
+			noParams
+		},
 		async ({}) => {
 			requireRobot();
 
@@ -363,7 +374,9 @@ export const createMcpServer = (): McpServer => {
 	tool(
 		"mobile_get_orientation",
 		"Get the current screen orientation of the device",
-		{},
+		{
+			noParams
+		},
 		async () => {
 			requireRobot();
 			const orientation = await robot!.getOrientation();


### PR DESCRIPTION
### ISSUE #89 
MCP error -32602: Invalid arguments for tool mobile_list_available_devices: [ { "code": "invalid_type", "expected": "object", "received": "undefined", "path": [], "message": "Required" } ] (Code -32602)


### Fixed
Added noParams scheme to prevent invalid arguments error.


### Demo

<img width="523" alt="Screenshot 2025-06-16 at 15 22 39" src="https://github.com/user-attachments/assets/0e2a9950-93a3-40d1-b382-48768cbc5a38" />


