### PR TITLE
Extensive listing of android elements

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -222,7 +222,7 @@ export class AndroidRobot implements Robot {
 			const element: ScreenElement = {
 				type: node.class || "element",
 				text: node.text,
-				label: node["content-desc"] || node.hint || "",
+				label: node["resource-id"] || node["content-desc"] || node.hint || "",
 				rect: this.getScreenElementRect(node),
 			};
 


### PR DESCRIPTION
I noticed sometimes buttons or elements not containing text are missed when listing elements. This seems to happen on Android, but iOS works fine.

**This will increase the token cost of Android tests.** I'm happy to make these changes behind a parameter, but based on iOS parity, I believe it makes more sense for this to be default.

<img width="506" alt="456094690-ef606968-5b53-425c-bc41-8cd9f8dc12d8" src="https://github.com/user-attachments/assets/a1853d5f-9423-4258-a267-d43576e6da6d" />

In this example, before we don't see the Pen icon in the elements list, but after we do:

Before (ignore the funky indentation):
```
Found these elements on screen: [{"type":"android.widget.TextView","text":"Environment: QA","label":"","coor
    dinates":{"x":313,"y":1245,"width":287,"height":38}},{"type":"android.widget.TextView","text":"Email
    Suffix","label":"","coordinates":{"x":42,"y":1419,"width":217,"height":44}},{"type":"android.widget.TextView
    ","text":"Email","label":"","coordinates":{"x":84,"y":1579,"width":86,"height":38}},{"type":"android.widget.
    EditText","text":"ben.myers+cardholder_1.com","label":"","identifier":"email_field","coordinates":{"x":
    42,"y":1556,"width":996,"height":147}},{"type":"android.widget.TextView","text":"Password","label":"","coord
    inates":{"x":84,"y":1768,"width":155,"height":38}},{"type":"android.widget.EditText","text":"•••••••••••••••
    ••••••••••","label":"","identifier":"password_field","coordinates":{"x":42,"y":1745,"width":996,"height":147
    }},{"type":"android.widget.TextView","text":"Log in via Email & Password","label":"","coordinates":{"x":310,
    "y":1976,"width":460,"height":38}}]
```


After:
```
Found these elements on screen: [{"type":"android.view.View","text":"","label":"","coor
    dinates":{"x":0,"y":0,"width":1080,"height":2400}},{"type":"com.feedback.FullScree
    nComposeViewContainer","text":"","label":"","coordinates":{"x":0,"y":0,"width":1080,"he
    ight":2400}},{"type":"android.view.View","text":"","label":"","coordinates":{"x":430,"y
    ":491,"width":221,"height":221}},{"type":"android.widget.TextView","text":"Environment:
     QA","label":"","coordinates":{"x":313,"y":1245,"width":287,"height":38}},{"type":"andr
    oid.widget.Button","text":"","label":"","coordinates":{"x":42,"y":1203,"width":828,"hei
    ght":122}},{"type":"android.view.View","text":"","label":"","coordinates":{"x":42,"y":1
    201,"width":828,"height":126}},{"type":"android.view.View","text":"","label":"","identi
    fier":"environment_selector","coordinates":{"x":42,"y":1161,"width":828,"height":164}},
    {"type":"android.view.View","text":"","label":"","coordinates":{"x":946,"y":1233,"width
    ":58,"height":58}},{"type":"android.widget.Button","text":"","label":"","coordinates":{
    "x":912,"y":1199,"width":126,"height":126}},{"type":"android.view.View","text":"","labe
    l":"","identifier":"fixture_login_button","coordinates":{"x":912,"y":1199,"width":126,"
    height":126}},{"type":"android.widget.TextView","text":"Email
    Suffix","label":"","coordinates":{"x":42,"y":1419,"width":217,"height":44}},{"type":"an
    droid.widget.EditText","text":"","label":"","identifier":"InputField[Email
    Suffix]","coordinates":{"x":42,"y":1367,"width":996,"height":147}},{"type":"android.wid
    get.TextView","text":"Email","label":"","coordinates":{"x":84,"y":1579,"width":86,"heig
    ht":38}},{"type":"android.widget.EditText","text":"ben.myers+cardholder_1.com","la
    bel":"","identifier":"email_field","coordinates":{"x":42,"y":1556,"width":996,"height":
    147}},{"type":"android.widget.TextView","text":"Password","label":"","coordinates":{"x"
    :84,"y":1768,"width":155,"height":38}},{"type":"android.widget.EditText","text":"••••••
    •••••••••••••••••••","label":"","identifier":"password_field","coordinates":{"x":42,"y"
    :1745,"width":996,"height":147}},{"type":"android.widget.TextView","text":"Log in via
    Email & Password","label":"","coordinates":{"x":310,"y":1976,"width":460,"height":38}},
    {"type":"android.widget.Button","text":"","label":"","coordinates":{"x":42,"y":1934,"wi
    dth":996,"height":122}},{"type":"android.view.View","text":"","label":"","identifier":"
    password_login_button","coordinates":{"x":42,"y":1932,"width":996,"height":126}},{"type
    ":"android.widget.TextView","text":"Log in","label":"","coordinates":{"x":415,"
    y":2140,"width":251,"height":38}},{"type":"android.widget.Button","text":"","label":"",
    "coordinates":{"x":42,"y":2098,"width":996,"height":122}},{"type":"android.view.View","
    text":"","label":"","identifier":"login_button","coordinates":{"x":42,"y":2096,"width":
    996,"height":126}},{"type":"android.widget.TextView","text":"0.98.0
    (9800)","label":"","coordinates":{"x":319,"y":2216,"width":442,"height":126}},{"type":"
    android.view.View","text":"","label":"","coordinates":{"x":0,"y":0,"width":1080,"height
    ":2400}},{"type":"android.view.View","text":"","label":"","coordinates":{"x":0,"y":0,"w
    idth":1080,"height":2400}},{"type":"com.android.ui.view.ComposeView","text":""
    ,"label":"","identifier":"com.android.app:id/fragment_compose_view","coordinates":
    {"x":0,"y":0,"width":1080,"height":2400}}]
```

which contains `{"type":"android.view.View","text":"","labe
    l":"","identifier":"fixture_login_button","coordinates":{"x":912,"y":1199,"width":126,"
    height":126}}`, the pen button.