### PR TITLE
Add tool mobile_tap_element

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -396,6 +396,46 @@ export const createMcpServer = (): McpServer => {
 		}
 	);
 
+	tool(
+		"mobile_tap_element",
+		"Find an element on screen by query and tap it. This combines list_elements and tap functionality.",
+		{
+			query: z.string().describe("Search query to find the element (matches against text, label, name, value, or identifier)")
+		},
+		async ({ query }) => {
+			requireRobot();
+			const elements = await robot!.getElementsOnScreen();
+
+			// Find matching element by searching text, label, name, value, and identifier
+			const matchingElement = elements.find(element => {
+				const searchFields = [
+					element.text,
+					element.label,
+					element.name,
+					element.value,
+					element.identifier
+				].filter(field => field && field.trim() !== "");
+
+				return searchFields.some(field =>
+					field && field.toLowerCase().includes(query.toLowerCase())
+				);
+			});
+
+			if (!matchingElement) {
+				throw new ActionableError(`No element found matching query: "${query}". Available elements: ${elements.map(e => e.text || e.label || e.name || e.value || e.identifier).filter(t => t).join(", ")}`);
+			}
+
+			// Calculate center coordinates of the element
+			const centerX = matchingElement.rect.x + (matchingElement.rect.width / 2);
+			const centerY = matchingElement.rect.y + (matchingElement.rect.height / 2);
+
+			// Tap the element
+			await robot!.tap(centerX, centerY);
+
+			return `Tapped element "${matchingElement.text || matchingElement.label || matchingElement.name || matchingElement.value || matchingElement.identifier}" at coordinates: ${centerX}, ${centerY}`;
+		}
+	);
+
 	// async check for latest agent version
 	checkForLatestAgentVersion().then();
 


### PR DESCRIPTION
### What does this do?

Adds a new MCP tool `mobile_tap_element` which taps an element matching query input. 

- This helps save token usage and time from listing elements on screen and then tapping the coordinates.
- After agents list elements to get their positions, they often tap the top-left corner of elements because thats what the positions represent. So, mobile_tap_element calculates the center coordinate and taps there. This increases reliability considering rounded elements whose touch zone doesn't contain the top-left corner.
- If operation fails to match the query, outputs the contents of list_elements.
- If operation matches multiple candidates, outputs all matched candidates element info.

### Testplan

In both cases below the element was successfully tapped on-simulator.

iOS

```
⏺ Now let me try tapping the "Reason for request" element:

⏺ mobile-mcp:mobile_tap_element (MCP)(query: "Reason for request")
  ⎿  Tapped element "Reason for request" at coordinates: 200, 654.5

⏺ Successfully tapped the "Reason for request" element at coordinates (200, 654.5).
```

Android

```
> Now do the same on android with element "Environment: QA"

⏺ I'll switch to an Android device and tap the "Environment: QA" element.

⏺ mobile-mcp:mobile_list_available_devices (MCP)(noParams: {})
  ⎿  Found these devices:               
     iOS simulators: [iPhone 16 Pro Max]
     Android devices: [emulator-5554]

⏺ mobile-mcp:mobile_use_device (MCP)(device: "emulator-5554", deviceType: "android")
  ⎿  Selected device: emulator-5554

⏺ mobile-mcp:mobile_tap_element (MCP)(query: "Environment: QA")
  ⎿  Tapped element "Environment: QA" at coordinates: 456.5, 1019

⏺ Successfully tapped the "Environment: QA" element at coordinates (456.5, 1019) on the Android device.
```