### PR TITLE
Add ios_use_booted parameter to mobile_take_screenshot

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -17,6 +17,11 @@ interface UiAutomatorXmlNode {
 	bounds?: string;
 	hint?: string;
 	focused?: string;
+	clickable?: string;
+	focusable?: string;
+	enabled?: string;
+	selected?: string;
+	package?: string;
 	"content-desc"?: string;
 	"resource-id"?: string;
 }
@@ -207,9 +212,15 @@ export class AndroidRobot implements Robot {
 			}
 		}
 
-		if (node.text || node["content-desc"] || node.hint) {
+		// Include elements with text/labels OR clickable/focusable elements (like icons, buttons)
+		const hasTextOrLabel = node.text || node["content-desc"] || node.hint || node["resource-id"];
+		const isInteractive = node.clickable === "true" || node.focusable === "true" ||
+			(node.class && (node.class.includes("Button") || node.class.includes("ImageView") ||
+			node.class.includes("ImageButton") || node.class.includes("View")));
+
+		if (hasTextOrLabel || isInteractive) {
 			const element: ScreenElement = {
-				type: node.class || "text",
+				type: node.class || "element",
 				text: node.text,
 				label: node["content-desc"] || node.hint || "",
 				rect: this.getScreenElementRect(node),

--- a/src/iphone-simulator.ts
+++ b/src/iphone-simulator.ts
@@ -61,6 +61,10 @@ export class Simctl implements Robot {
 		return this.simctl("io", this.simulatorUuid, "screenshot", "-");
 	}
 
+	public async getScreenshotBooted(): Promise<Buffer> {
+		return this.simctl("io", "booted", "screenshot", "-");
+	}
+
 	public async openUrl(url: string) {
 		const wda = await this.wda();
 		await wda.openUrl(url);

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -67,6 +67,12 @@ export interface Robot {
 	getScreenshot(): Promise<Buffer>;
 
 	/**
+	 * Get a screenshot of the screen using booted simulator (iOS only).
+	 * For non-iOS devices, this should behave the same as getScreenshot().
+	 */
+	getScreenshotBooted?(): Promise<Buffer>;
+
+	/**
 	 * List all installed apps on the device. Returns an array of package names (or
 	 * bundle identifiers in iOS) for all installed apps.
 	 */

--- a/src/server.ts
+++ b/src/server.ts
@@ -322,15 +322,20 @@ export const createMcpServer = (): McpServer => {
 		"mobile_take_screenshot",
 		"Take a screenshot of the mobile device. Use this to understand what's on screen, if you need to press an element that is available through view hierarchy then you must list elements on screen instead. Do not cache this result.",
 		{
-			noParams
+			ios_use_booted: z.boolean().optional().describe("Whether to use the booted simulator instead of the selected device UUID. Defaults to false.")
 		},
-		async ({}) => {
+		async ({ ios_use_booted = false }) => {
 			requireRobot();
 
 			try {
 				const screenSize = await robot!.getScreenSize();
 
-				let screenshot = await robot!.getScreenshot();
+				let screenshot: Buffer;
+				if (ios_use_booted && robot!.getScreenshotBooted) {
+					screenshot = await robot!.getScreenshotBooted();
+				} else {
+					screenshot = await robot!.getScreenshot();
+				}
 				let mimeType = "image/png";
 
 				// validate we received a png, will throw exception otherwise

--- a/src/server.ts
+++ b/src/server.ts
@@ -396,6 +396,46 @@ export const createMcpServer = (): McpServer => {
 		}
 	);
 
+	tool(
+		"mobile_tap_element",
+		"Find an element on screen by query and tap it. This combines list_elements and tap functionality.",
+		{
+			query: z.string().describe("Search query to find the element (matches against text, label, name, value, or identifier)")
+		},
+		async ({ query }) => {
+			requireRobot();
+			const elements = await robot!.getElementsOnScreen();
+
+			// Find matching element by searching text, label, name, value, and identifier
+			const matchingElement = elements.find(element => {
+				const searchFields = [
+					element.text,
+					element.label,
+					element.name,
+					element.value,
+					element.identifier
+				].filter(field => field && field.trim() !== "");
+
+				return searchFields.some(field =>
+					field && field.toLowerCase().includes(query.toLowerCase())
+				);
+			});
+
+			if (!matchingElement) {
+				throw new ActionableError(`No element found matching query: "${query}". Available elements: ${elements.map(e => e.text || e.label || e.name || e.value || e.identifier).filter(t => t).join(", ")}`);
+			}
+
+			// Calculate center coordinates of the element
+			const centerX = matchingElement.rect.x + (matchingElement.rect.width / 2);
+			const centerY = matchingElement.rect.y + (matchingElement.rect.height / 2);
+
+			// Tap the element
+			await robot!.tap(centerX, centerY);
+
+			return `Tapped element "${matchingElement.text || matchingElement.label || matchingElement.name || matchingElement.value || matchingElement.identifier}" at coordinates: ${centerX}, ${centerY}`;
+		}
+	);
+
 	// async check for latest agent version
 	checkForLatestAgentVersion().then();
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -324,7 +324,7 @@ export const createMcpServer = (): McpServer => {
 		{
 			ios_use_booted: z.boolean().optional().describe("Whether to use the booted simulator instead of the selected device UUID. Defaults to false.")
 		},
-		async ({ ios_use_booted = false }) => {
+		async ({ ios_use_booted = true }) => {
 			requireRobot();
 
 			try {


### PR DESCRIPTION
Often mobile_take_screenshot fails to work on iOS. The logic that takes a screenshot on the selected device by UDID can return errors with no information. 

This PR adds a parameter `ios_use_booted` which calls `xcrun simctl io booted screenshot` under the hood. This command simply looks for any booted simulator and takes a screenshot, having increased reliability.

I made the parameter default to `false` because this does not support testing with multiple simulators.