### PR TITLE
Add ios_use_booted parameter to mobile_take_screenshot

### DIFF
--- a/src/iphone-simulator.ts
+++ b/src/iphone-simulator.ts
@@ -61,6 +61,10 @@ export class Simctl implements Robot {
 		return this.simctl("io", this.simulatorUuid, "screenshot", "-");
 	}
 
+	public async getScreenshotBooted(): Promise<Buffer> {
+		return this.simctl("io", "booted", "screenshot", "-");
+	}
+
 	public async openUrl(url: string) {
 		const wda = await this.wda();
 		await wda.openUrl(url);

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -67,6 +67,12 @@ export interface Robot {
 	getScreenshot(): Promise<Buffer>;
 
 	/**
+	 * Get a screenshot of the screen using booted simulator (iOS only).
+	 * For non-iOS devices, this should behave the same as getScreenshot().
+	 */
+	getScreenshotBooted?(): Promise<Buffer>;
+
+	/**
 	 * List all installed apps on the device. Returns an array of package names (or
 	 * bundle identifiers in iOS) for all installed apps.
 	 */

--- a/src/server.ts
+++ b/src/server.ts
@@ -322,15 +322,20 @@ export const createMcpServer = (): McpServer => {
 		"mobile_take_screenshot",
 		"Take a screenshot of the mobile device. Use this to understand what's on screen, if you need to press an element that is available through view hierarchy then you must list elements on screen instead. Do not cache this result.",
 		{
-			noParams
+			ios_use_booted: z.boolean().optional().describe("Whether to use the booted simulator instead of the selected device UUID. Defaults to false.")
 		},
-		async ({}) => {
+		async ({ ios_use_booted = false }) => {
 			requireRobot();
 
 			try {
 				const screenSize = await robot!.getScreenSize();
 
-				let screenshot = await robot!.getScreenshot();
+				let screenshot: Buffer;
+				if (ios_use_booted && robot!.getScreenshotBooted) {
+					screenshot = await robot!.getScreenshotBooted();
+				} else {
+					screenshot = await robot!.getScreenshot();
+				}
 				let mimeType = "image/png";
 
 				// validate we received a png, will throw exception otherwise


### PR DESCRIPTION
Often mobile_take_screenshot fails to work on iOS. The logic that takes a screenshot on the selected device by UDID can return errors with no information. 

This PR adds a parameter `ios_use_booted` which calls `xcrun simctl io booted screenshot` under the hood. This command simply looks for any booted simulator and takes a screenshot, having increased reliability.

I made the parameter default to `false` because this does not support testing with multiple simulators.