### PR TITLE
Add tool mobile_get_logs

### DIFF
--- a/src/ios.ts
+++ b/src/ios.ts
@@ -195,7 +195,7 @@ export class IosRobot implements Robot {
 		return await wda.getOrientation();
 	}
 
-	public async getDeviceLogs(options?: { timeWindow?: string; filter?: string; boolean; process?: string }): Promise<string> {
+	public async getDeviceLogs(options?: { timeWindow?: string; filter?: string; process?: string }): Promise<string> {
 		await this.assertTunnelRunning();
 		const timeWindow = options?.timeWindow || "1m";
 		const filter = options?.filter;

--- a/src/iphone-simulator.ts
+++ b/src/iphone-simulator.ts
@@ -132,6 +132,81 @@ export class Simctl implements Robot {
 		const wda = await this.wda();
 		return wda.getOrientation();
 	}
+
+	public async getDeviceLogs(options?: { timeWindow?: string; filter?: string; process?: string }): Promise<string> {
+		const timeWindow = options?.timeWindow || "1m";
+		const filter = options?.filter;
+		const processFilter = options?.process;
+		let deviceUuid = this.simulatorUuid;
+		if (useBooted) {
+			const bootedSimulators = new SimctlManager().listBootedSimulators();
+			if (bootedSimulators.length === 0) {
+				throw new ActionableError("No booted simulator found. Please start a simulator first.");
+			}
+			deviceUuid = bootedSimulators[0].uuid;
+		}
+
+		let predicate = "";
+		let currentApp: string | null = null;
+
+		// If a specific process is provided, use that
+		if (processFilter) {
+			currentApp = processFilter;
+			predicate = `subsystem == "${processFilter}"`;
+		} else {
+			// Try to detect currently running user apps from installed apps
+			try {
+				let runningApps;
+				if (useBooted) {
+					runningApps = await this.listAppsBooted();
+				} else {
+					runningApps = await this.listApps();
+				}
+
+				// Filter to non-Apple user apps
+				const userApps = runningApps
+					.map(app => app.packageName)
+					.filter(appId => !appId.startsWith("com.apple.") && appId.includes("."));
+
+				if (userApps.length > 0) {
+					// For now, just use the first user app found
+					// In the future, we could try to detect which is actually running
+					currentApp = userApps[0];
+					predicate = `subsystem == "${currentApp}"`;
+				}
+			} catch (error) {
+				// Failed to get apps, continue with fallback
+			}
+
+			// If no user app detected, use broader filter for non-Apple apps
+			if (!predicate) {
+				predicate = "subsystem CONTAINS \"com.\" AND NOT subsystem BEGINSWITH \"com.apple.\"";
+			}
+		}
+		if (filter) {
+			predicate += ` AND composedMessage CONTAINS[c] "${filter}"`;
+		}
+
+		const args = [
+			"spawn", deviceUuid, "log", "show",
+			"--last", timeWindow,
+			"--predicate", predicate,
+			"--info",
+			"--debug"
+		];
+
+		try {
+			const logs = this.simctl(...args).toString();
+			const appInfo = currentApp ? ` (focused on: ${currentApp})` : " (all non-Apple apps)";
+			const debugInfo = `DEBUG: Using predicate: ${predicate}${appInfo}\n\n`;
+			return `${debugInfo}${logs}`;
+		} catch (error) {
+			if (error instanceof Error && error.message.includes("No logging subsystem")) {
+				return "No logs found for the current running applications.";
+			}
+			throw error;
+		}
+	}
 }
 
 export class SimctlManager {

--- a/src/iphone-simulator.ts
+++ b/src/iphone-simulator.ts
@@ -137,14 +137,7 @@ export class Simctl implements Robot {
 		const timeWindow = options?.timeWindow || "1m";
 		const filter = options?.filter;
 		const processFilter = options?.process;
-		let deviceUuid = this.simulatorUuid;
-		if (useBooted) {
-			const bootedSimulators = new SimctlManager().listBootedSimulators();
-			if (bootedSimulators.length === 0) {
-				throw new ActionableError("No booted simulator found. Please start a simulator first.");
-			}
-			deviceUuid = bootedSimulators[0].uuid;
-		}
+		const deviceUuid = this.simulatorUuid;
 
 		let predicate = "";
 		let currentApp: string | null = null;
@@ -156,17 +149,12 @@ export class Simctl implements Robot {
 		} else {
 			// Try to detect currently running user apps from installed apps
 			try {
-				let runningApps;
-				if (useBooted) {
-					runningApps = await this.listAppsBooted();
-				} else {
-					runningApps = await this.listApps();
-				}
+				const runningApps = await this.listApps();
 
 				// Filter to non-Apple user apps
 				const userApps = runningApps
-					.map(app => app.packageName)
-					.filter(appId => !appId.startsWith("com.apple.") && appId.includes("."));
+					.map((app: InstalledApp) => app.packageName)
+					.filter((appId: string) => !appId.startsWith("com.apple.") && appId.includes("."));
 
 				if (userApps.length > 0) {
 					// For now, just use the first user app found

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -120,4 +120,9 @@ export interface Robot {
 	 * Get the current screen orientation.
 	 */
 	getOrientation(): Promise<Orientation>;
+
+	/**
+	 * Get device logs with optional filtering.
+	 */
+	getDeviceLogs(options?: { timeWindow?: string; filter?: string; process?: string }): Promise<string>;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -451,66 +451,6 @@ export const createMcpServer = (): McpServer => {
 	);
 
 	tool(
-		"mobile_tap_element",
-		"Find an element on screen by query and tap it. This combines list_elements and tap functionality.",
-		{
-			query: z.string().describe("Search query to find the element (matches against text, label, name, value, or identifier)")
-		},
-		async ({ query }) => {
-			requireRobot();
-			const elements = await robot!.getElementsOnScreen();
-
-			// Find all matching elements by searching text, label, name, value, and identifier
-			const matchingElements = elements.filter(element => {
-				const searchFields = [
-					element.text,
-					element.label,
-					element.name,
-					element.value,
-					element.identifier
-				].filter(field => field && field.trim() !== "");
-
-				return searchFields.some(field =>
-					field && field.toLowerCase().includes(query.toLowerCase())
-				);
-			});
-
-			if (matchingElements.length === 0) {
-				throw new ActionableError(`No element found matching query: "${query}". Available elements: ${elements.map(e => e.text || e.label || e.name || e.value || e.identifier).filter(t => t).join(", ")}`);
-			}
-
-			if (matchingElements.length > 1) {
-				const matchingElementsJson = matchingElements.map(element => ({
-					type: element.type,
-					text: element.text,
-					label: element.label,
-					name: element.name,
-					value: element.value,
-					identifier: element.identifier,
-					coordinates: {
-						x: element.rect.x + (element.rect.width / 2),
-						y: element.rect.y + (element.rect.height / 2)
-					},
-					rect: element.rect
-				}));
-
-				throw new ActionableError(`Multiple elements found matching query: "${query}". Found ${matchingElements.length} matches:\n${JSON.stringify(matchingElementsJson, null, 2)}`);
-			}
-
-			const matchingElement = matchingElements[0];
-
-			// Calculate center coordinates of the element
-			const centerX = matchingElement.rect.x + (matchingElement.rect.width / 2);
-			const centerY = matchingElement.rect.y + (matchingElement.rect.height / 2);
-
-			// Tap the element
-			await robot!.tap(centerX, centerY);
-
-			return `Tapped element "${matchingElement.text || matchingElement.label || matchingElement.name || matchingElement.value || matchingElement.identifier}" at coordinates: ${centerX}, ${centerY}`;
-		}
-	);
-
-	tool(
 		"mobile_get_log",
 		"Get device logs with optional filtering. For iOS simulators, gets logs from running apps using log show command. For iOS physical devices, gets system logs. For Android devices, gets logcat output.",
 		{

--- a/src/server.ts
+++ b/src/server.ts
@@ -451,12 +451,12 @@ export const createMcpServer = (): McpServer => {
 	);
 
 	tool(
-		"mobile_get_log",
-		"Get device logs with optional filtering. For iOS simulators, gets logs from running apps using log show command. For iOS physical devices, gets system logs. For Android devices, gets logcat output.",
+		"mobile_get_logs",
+		"Get device logs",
 		{
 			timeWindow: z.string().optional().describe("Time window to look back (e.g., '5m' for 5 minutes, '1h' for 1 hour). Defaults to '1m'"),
 			filter: z.string().optional().describe("Filter logs containing this query (case-insensitive). For Android: supports 'package:mine <query>' (user apps only), 'package:com.app.bundle <query>' (specific app), or '<query>' (text search). For iOS: simple text search only."),
-			process: z.string().optional().describe("Filter logs to a specific process/app bundle ID (e.g., 'com.ramp.Ramp.ios'). Can be combined with 'filter' for text search within that process. If not provided, attempts to auto-detect running user apps.")
+			process: z.string().optional().describe("Filter logs to a specific process/app bundle ID")
 		},
 		async ({ timeWindow, filter, process }) => {
 			requireRobot();


### PR DESCRIPTION
Adds a tool to fetch device logs.

Parameters:
- `timeWindow`: e.g. '5m', '1m', '30s'
- `filter`: Filters log entries matching query
- `process`: Filters log entries matching process (bundle id)

iOS
```
⏺ mobile-mcp:mobile_get_log (MCP)(process: "com.MyApp.MyApp.ios", iosUseBooted: true)
  ⎿ Device logs (process: com.MyApp.MyApp.ios):                                                                                                                                      
    DEBUG: Using predicate: subsystem == 'com.MyApp.MyApp.ios' (focused on: com.MyApp.MyApp.ios)

    Timestamp                       Thread     Type        Activity             PID    TTL
    2025-06-20 14:46:52.176511-0700 0x1015c94  Info        0x0                  77887  0    MyApp: [com.MyApp.MyApp.ios:Breadcrumb] Breadcrumb(kind:
    MyAppLogging.Breadcrumb.Kind.default, category: "default", message: "[WebView] Updating state: pushing to history via JS bridge", level: MyAppLogging.Breadcrumb.Level.debug,
    info: Optional(["_file": "WebView/WebViewController.swift", "_function": "updateState(to:)", "_line": "139"]))
    2025-06-20 14:46:52.189383-0700 0x1015c94  Info        0x0                  77887  0    MyApp: [com.MyApp.MyApp.ios:Transition] ViewTransition(name: "SpendLimitDetailView",
    category: MyAppLogging.ViewInfo.Category.screen, transition: MyAppLogging.ViewTransition.Transition.appear, viewID: "C97A549C-0FE1-49F5-A75C-6C1A0B654CEF")
    2025-06-20 14:46:52.189432-0700 0x1015c94  Info        0x0                  77887  0    MyApp: [com.MyApp.MyApp.ios:Transition] ViewTransition(name: "BottomSheetContainer",
    category: MyAppLogging.ViewInfo.Category.screen, transition: ...
MyAppLogging.ViewTransition.Transition.appear, viewID: "75EBB2BB-FE07-4F25-877E-9C7ADC4DD778")
    2025-06-20 14:47:01.735983-0700 0x1015c94  Info        0x0                  77887  0    MyApp: [com.MyApp.MyApp.ios:Transition] ViewTransition(name: "EditSpendView", category:
    MyAppLogging.ViewInfo.Category.screen, transition: MyAppLogging.ViewTransition.Transition.appear, viewID: "7A165BB1-D648-44F6-9203-DEAC253C4373")
```

Android
```
⏺ mobile-mcp:mobile_get_log (MCP)(process: "com.MyApp.android.app", timeWindow: "1m", filter: "MyApp Logging")
  ⎿  Device logs from last 1m (filtered by: MyApp Logging) (process: com.MyApp.android.app):                                                                                   
     06-20 15:14:56.540  4531 10163 I MyApp Logging: id: c1111c40-ec1f-4411-9601-d39fba972af8
     06-20 15:14:56.540  4531 10163 I MyApp Logging: Time: 15:14:56.531
     06-20 15:14:56.540  4531 10163 I MyApp Logging: Type: Breadcrumb
     06-20 15:14:56.540  4531 10163 I MyApp Logging: Preview: [WebView] history updated: https://qa.MyApp.com/mobile/transactions/649aa426-303d-4a30-8ebf-753446b5256d/activity

⏺ Android MyApp Logs Analysis:
  New activity showing continued navigation:

  - Different Transaction: User navigated to a different transaction (649aa426-303d-4a30-8ebf-753446b5256d)
  - Same Pattern: Still viewing transaction activity pages in WebView
  - Recent Activity: Occurred at 15:14:56 (just now)
  - QA Environment: Still using the QA environment

  The user is actively browsing between different transaction activity pages within the MyApp Android app.
```