### PR TITLE
Fix: Fail to check go-ios installation

### DIFF
--- a/src/ios.ts
+++ b/src/ios.ts
@@ -199,7 +199,7 @@ export class IosRobot implements Robot {
 
 export class IosManager {
 
-	public async isGoIosInstalled(): Promise<boolean> {
+	public isGoIosInstalled(): boolean {
 		try {
 			const output = execFileSync(getGoIosPath(), ["version"], { stdio: ["pipe", "pipe", "ignore"] }).toString();
 			const json: VersionCommandOutput = JSON.parse(output);


### PR DESCRIPTION
### Problem
There was an async/await mismatch in the iOS device management code that was causing the application to fail when checking for go-ios installation and listing iOS devices.

Error:
```
spawnSync ios ENOENT
```

The issue occurred because: `isGoIosInstalled()` was incorrectly marked as `async` despite using synchronous `execFileSync`


### Solution
**Fixed the async/await pattern consistency:**

Made `isGoIosInstalled()` synchronous. Removed `async` keyword and `Promise<boolean>` return type since it uses `execFileSync()` which is inherently synchronous

### Impact
- Fixes runtime errors when calling `mobile_list_available_devices`

### Testing
Able to get available devices when calling `mobile_list_available_devices`.

```
npx @modelcontextprotocol/inspector node lib/index.js
```

<img width="1484" alt="Screenshot 2025-07-02 at 15 34 20" src="https://github.com/user-attachments/assets/9d7d1563-7e92-4d21-bfec-565f66d46f45" />
