### PR TITLE
fix: get screen density of android devices

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -96,11 +96,7 @@ export class AndroidRobot implements Robot {
 			.split(" ")
 			.pop();
 
-		if (!screenDensity) {
-			throw new Error("Failed to get screen density");
-		}
-
-		const scale = +screenDensity / 160;
+		const scale = screenDensity ? +screenDensity / 160 : 1;
 		const [width, height] = screenSize.split("x").map(Number);
 		return { width, height, scale };
 	}

--- a/src/android.ts
+++ b/src/android.ts
@@ -91,7 +91,16 @@ export class AndroidRobot implements Robot {
 			throw new Error("Failed to get screen size");
 		}
 
-		const scale = 1;
+		const screenDensity = this.adb("shell", "wm", "density")
+			.toString()
+			.split(" ")
+			.pop();
+
+		if (!screenDensity) {
+			throw new Error("Failed to get screen density");
+		}
+
+		const scale = +screenDensity / 160;
 		const [width, height] = screenSize.split("x").map(Number);
 		return { width, height, scale };
 	}


### PR DESCRIPTION
Image compression is using `screenSize.scale` as the resize factor:

https://github.com/mobile-next/mobile-mcp/blob/4c026a6e4620cad42044aff01c4df6a7e0b63780/src/server.ts#L439

But `scale` is currently hard-coded to `1` for Android, so while the file size is reduced, the resolution of the image won't be scaled, causing https://github.com/mobile-next/mobile-mcp/issues/140.