### PR TITLE
feat: add iOS booted simulator support

### DIFF
--- a/src/iphone-simulator.ts
+++ b/src/iphone-simulator.ts
@@ -106,6 +106,10 @@ export class Simctl implements Robot {
 		// alternative: return this.simctl("io", this.simulatorUuid, "screenshot", "-");
 	}
 
+	public async getScreenshotBooted(): Promise<Buffer> {
+		return this.simctl("io", "booted", "screenshot", "-");
+	}
+
 	public async openUrl(url: string) {
 		const wda = await this.wda();
 		await wda.openUrl(url);
@@ -116,8 +120,16 @@ export class Simctl implements Robot {
 		this.simctl("launch", this.simulatorUuid, packageName);
 	}
 
+	public async launchAppBooted(packageName: string) {
+		this.simctl("launch", "booted", packageName);
+	}
+
 	public async terminateApp(packageName: string) {
 		this.simctl("terminate", this.simulatorUuid, packageName);
+	}
+
+	public async terminateAppBooted(packageName: string) {
+		this.simctl("terminate", "booted", packageName);
 	}
 
 	private findAppBundle(dir: string): string | null {
@@ -215,6 +227,19 @@ export class Simctl implements Robot {
 
 	public async listApps(): Promise<InstalledApp[]> {
 		const text = this.simctl("listapps", this.simulatorUuid).toString();
+		const result = execFileSync("plutil", ["-convert", "json", "-o", "-", "-r", "-"], {
+			input: text,
+		});
+
+		const output = JSON.parse(result.toString()) as Record<string, AppInfo>;
+		return Object.values(output).map(app => ({
+			packageName: app.CFBundleIdentifier,
+			appName: app.CFBundleDisplayName,
+		}));
+	}
+
+	public async listAppsBooted(): Promise<InstalledApp[]> {
+		const text = this.simctl("listapps", "booted").toString();
 		const result = execFileSync("plutil", ["-convert", "json", "-o", "-", "-r", "-"], {
 			input: text,
 		});

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -67,10 +67,22 @@ export interface Robot {
 	getScreenshot(): Promise<Buffer>;
 
 	/**
+	 * Get a screenshot of the screen using booted simulator (iOS only).
+	 * For non-iOS devices, this should behave the same as getScreenshot().
+	 */
+	getScreenshotBooted?(): Promise<Buffer>;
+
+	/**
 	 * List all installed apps on the device. Returns an array of package names (or
 	 * bundle identifiers in iOS) for all installed apps.
 	 */
 	listApps(): Promise<InstalledApp[]>;
+
+	/**
+	 * List all installed apps using booted simulator (iOS only).
+	 * For non-iOS devices, this should behave the same as listApps().
+	 */
+	listAppsBooted?(): Promise<InstalledApp[]>;
 
 	/**
 	 * Launch an app.
@@ -78,10 +90,22 @@ export interface Robot {
 	launchApp(packageName: string): Promise<void>;
 
 	/**
+	 * Launch an app using booted simulator (iOS only).
+	 * For non-iOS devices, this should behave the same as launchApp().
+	 */
+	launchAppBooted?(packageName: string): Promise<void>;
+
+	/**
 	 * Terminate an app. If app was already terminated (or non existent) then this
 	 * is a no-op.
 	 */
 	terminateApp(packageName: string): Promise<void>;
+
+	/**
+	 * Terminate an app using booted simulator (iOS only).
+	 * For non-iOS devices, this should behave the same as terminateApp().
+	 */
+	terminateAppBooted?(packageName: string): Promise<void>;
 
 	/**
 	 * Install an app on the device from a file path.


### PR DESCRIPTION
Add methods to interact with the 'booted' simulator without needing device UUID.
This enables CI/CD workflows and automation scripts to work with whichever
simulator is currently booted.

- Add getScreenshotBooted() for screenshot capture
- Add launchAppBooted() and terminateAppBooted() for app lifecycle
- Add listAppsBooted() to enumerate installed apps
- Update Robot interface with optional booted methods
- All methods use 'booted' identifier instead of specific UUID

Co-Authored-By: @benlmyers 
