### PR TITLE
Platform-specific ADB paths

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -41,7 +41,7 @@ const getAdbPath = (): string => {
 		}
 	}
 
-	if (process.env.HOME) {
+	if (process.platform === "darwin" && process.env.HOME) {
 		const defaultAndroidSdk = path.join(process.env.HOME, "Library", "Android", "sdk", "platform-tools", "adb");
 		if (existsSync(defaultAndroidSdk)) {
 			return defaultAndroidSdk;


### PR DESCRIPTION
Fixes https://github.com/mobile-next/mobile-mcp/issues/229
Also adds a platform check for MacOS before using the macos-specific install path.