### PR TITLE
feat: add optional maxBufferBytes to mobile_take_screenshot

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -292,7 +292,7 @@ export class AndroidRobot implements Robot {
 		return null;
 	}
 
-	public async getScreenshot(): Promise<Buffer> {
+	public async getScreenshot(_maxBufferBytes?: number): Promise<Buffer> {
 		if (this.getDisplayCount() <= 1) {
 			// backward compatibility for android 10 and below, and for single display devices
 			return this.adb("exec-out", "screencap", "-p");

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -206,7 +206,7 @@ export class IosRobot implements Robot {
 		return await wda.getElementsOnScreen();
 	}
 
-	public async getScreenshot(): Promise<Buffer> {
+	public async getScreenshot(_maxBufferBytes?: number): Promise<Buffer> {
 		const wda = await this.wda();
 		return await wda.getScreenshot();
 

--- a/src/iphone-simulator.ts
+++ b/src/iphone-simulator.ts
@@ -89,7 +89,7 @@ export class Simctl implements Robot {
 		});
 	}
 
-	public async getScreenshot(): Promise<Buffer> {
+	public async getScreenshot(_maxBufferBytes?: number): Promise<Buffer> {
 		const wda = await this.wda();
 		return await wda.getScreenshot();
 		// alternative: return this.simctl("io", this.simulatorUuid, "screenshot", "-");

--- a/src/mobile-device.ts
+++ b/src/mobile-device.ts
@@ -136,9 +136,9 @@ export class MobileDevice implements Robot {
 		this.runCommand(["io", "swipe", `${x},${y},${endX},${endY}`]);
 	}
 
-	public async getScreenshot(): Promise<Buffer> {
+	public async getScreenshot(maxBufferBytes?: number): Promise<Buffer> {
 		const fullArgs = ["screenshot", "--device", this.deviceId, "--format", "png", "--output", "-"];
-		return this.mobilecli.executeCommandBuffer(fullArgs);
+		return this.mobilecli.executeCommandBuffer(fullArgs, maxBufferBytes);
 	}
 
 	public async listApps(): Promise<InstalledApp[]> {

--- a/src/mobilecli.ts
+++ b/src/mobilecli.ts
@@ -41,11 +41,12 @@ export class Mobilecli {
 		return execFileSync(path, args, { encoding: "utf8" }).toString().trim();
 	}
 
-	public executeCommandBuffer(args: string[]): Buffer {
+	public executeCommandBuffer(args: string[], maxBufferBytes?: number): Buffer {
 		const path = this.getPath();
+		const maxBuffer = maxBufferBytes ?? MAX_BUFFER_SIZE;
 		return execFileSync(path, args, {
 			encoding: "buffer",
-			maxBuffer: MAX_BUFFER_SIZE,
+			maxBuffer,
 			timeout: TIMEOUT,
 		}) as Buffer;
 	}

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -63,8 +63,10 @@ export interface Robot {
 	/**
 	 * Get a screenshot of the screen. Returns a Buffer that contains
 	 * a PNG image of the screen. Will be same dimensions as getScreenSize().
+	 * maxBufferBytes can be used by implementations that execute external
+	 * commands and need to adjust stdout buffer limits.
 	 */
-	getScreenshot(): Promise<Buffer>;
+	getScreenshot(maxBufferBytes?: number): Promise<Buffer>;
 
 	/**
 	 * List all installed apps on the device. Returns an array of package names (or

--- a/src/server.ts
+++ b/src/server.ts
@@ -546,20 +546,21 @@ export const createMcpServer = (): McpServer => {
 		"mobile_take_screenshot",
 		{
 			title: "Take Screenshot",
-			description: "Take a screenshot of the mobile device. Use this to understand what's on screen, if you need to press an element that is available through view hierarchy then you must list elements on screen instead. Do not cache this result.",
+			description: "Take a screenshot of the mobile device. Use this to understand what's on screen, if you need to press an element that is available through view hierarchy then you must list elements on screen instead. Do not cache this result. maxBufferBytes defaults to 4194304 (4MB) and can be overridden for high-resolution screenshots.",
 			inputSchema: {
-				device: z.string().describe("The device identifier to use. Use mobile_list_available_devices to find which devices are available to you.")
+				device: z.string().describe("The device identifier to use. Use mobile_list_available_devices to find which devices are available to you."),
+				maxBufferBytes: z.number().int().positive().optional().describe("Maximum stdout buffer in bytes used while taking the screenshot. Default is 4194304 (4MB). Increase this if you hit ENOBUFS on high-resolution devices."),
 			},
 			annotations: {
 				readOnlyHint: true,
 			},
 		},
-		async ({ device }) => {
+		async ({ device, maxBufferBytes }) => {
 			try {
 				const robot = getRobotFromDevice(device);
 				const screenSize = await robot.getScreenSize();
 
-				let screenshot = await robot.getScreenshot();
+				let screenshot = await robot.getScreenshot(maxBufferBytes);
 				let mimeType = "image/png";
 
 				// validate we received a png, will throw exception otherwise

--- a/test/mobile-device.ts
+++ b/test/mobile-device.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert";
+import { MobileDevice } from "../src/mobile-device";
+import { Mobilecli } from "../src/mobilecli";
+
+describe("mobile-device", () => {
+	const screenshotArgs = ["screenshot", "--device", "test-device", "--format", "png", "--output", "-"];
+
+	it("should forward maxBufferBytes when taking a screenshot", async () => {
+		const device = new MobileDevice("test-device");
+		const calls: Array<{ args: string[]; maxBufferBytes?: number }> = [];
+		const screenshotBuffer = Buffer.from("test-image");
+
+		(device as any).mobilecli = {
+			executeCommandBuffer: (args: string[], maxBufferBytes?: number) => {
+				calls.push({ args, maxBufferBytes });
+				return screenshotBuffer;
+			},
+		} as Mobilecli;
+
+		const result = await device.getScreenshot(8 * 1024 * 1024);
+
+		assert.equal(result, screenshotBuffer);
+		assert.equal(calls.length, 1);
+		assert.deepEqual(calls[0].args, screenshotArgs);
+		assert.equal(calls[0].maxBufferBytes, 8 * 1024 * 1024);
+	});
+
+	it("should keep maxBufferBytes undefined when not provided", async () => {
+		const device = new MobileDevice("test-device");
+		const calls: Array<{ args: string[]; maxBufferBytes?: number }> = [];
+		const screenshotBuffer = Buffer.from("test-image");
+
+		(device as any).mobilecli = {
+			executeCommandBuffer: (args: string[], maxBufferBytes?: number) => {
+				calls.push({ args, maxBufferBytes });
+				return screenshotBuffer;
+			},
+		} as Mobilecli;
+
+		const result = await device.getScreenshot();
+
+		assert.equal(result, screenshotBuffer);
+		assert.equal(calls.length, 1);
+		assert.deepEqual(calls[0].args, screenshotArgs);
+		assert.equal(calls[0].maxBufferBytes, undefined);
+	});
+});


### PR DESCRIPTION
## Summary
This PR adds an optional `maxBufferBytes` parameter to `mobile_take_screenshot`, allowing callers to override the stdout buffer limit used during screenshot capture.

When not provided, behavior remains unchanged: the default buffer size is still **4MB**.

## What Changed
- Added `maxBufferBytes` (optional) to `mobile_take_screenshot` input schema.
- Updated `Robot#getScreenshot(maxBufferBytes?)` to accept an optional buffer override.
- Propagated the value through:
  - `server` -> `Robot` -> `MobileDevice` -> `Mobilecli`
- Updated `Mobilecli#executeCommandBuffer(args, maxBufferBytes?)` to use the override when provided.
- Added `mobile-device` unit tests to verify forwarding behavior.

## Backward Compatibility
- `maxBufferBytes` is optional.
- Default remains 4MB.
- Existing clients require no changes.

## Validation
- `npm run build` (Node 22)
- `npm test -- --grep 'mobile-device|mobilecli'` (Node 22)

## Related
- #236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Screenshot functionality now supports optional buffer size configuration. Users can specify a custom maximum buffer size when capturing device screenshots, enabling better handling of high-resolution images and scenarios where the default buffer size may be insufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->