### PR TITLE
prime lazy loaded accessibility tree

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -349,8 +349,8 @@ export class AndroidRobot implements Robot {
 	}
 
 	public async getElementsOnScreen(): Promise<ScreenElement[]> {
-		// Prime lazy loaded accessibility tree
-		await this.getUiAutomatorXml();
+		// Prime lazy loaded accessibility tree (raw dump, no parsing)
+		await this.getUiAutomatorDump();
 
 		const parsedXml = await this.getUiAutomatorXml();
 		const hierarchy = parsedXml.hierarchy;


### PR DESCRIPTION
WebView accessibility tree populates asynchronously on first access. The second call always seemed to work so after some research it seems this is the case. This is the best solution I could come up with.

First call primes the tree, second call returns complete cached data.