### PR TITLE
fix: handle errors in getDeviceType to prevent empty device list

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -519,13 +519,17 @@ export class AndroidRobot implements Robot {
 export class AndroidDeviceManager {
 
 	private getDeviceType(name: string): AndroidDeviceType {
-		const device = new AndroidRobot(name);
-		const features = device.getSystemFeatures();
-		if (features.includes("android.software.leanback") || features.includes("android.hardware.type.television")) {
-			return "tv";
+		try {
+			const device = new AndroidRobot(name);
+			const features = device.getSystemFeatures();
+			if (features.includes("android.software.leanback") || features.includes("android.hardware.type.television")) {
+				return "tv";
+			}
+			return "mobile";
+		} catch (error) {
+			// Fallback to mobile if we cannot determine device type
+			return "mobile";
 		}
-
-		return "mobile";
 	}
 
 	private getDeviceVersion(deviceId: string): string {


### PR DESCRIPTION
## Summary

- Added try-catch to `getDeviceType()` in `AndroidDeviceManager` to handle devices that don't support `pm list features` command
- Falls back to "mobile" type when device features cannot be determined, consistent with error handling in `getDeviceVersion()` and `getDeviceName()`

## Problem

Some Android devices (e.g., automotive units, custom ROMs) do not support the `adb shell pm list features` command. When `getDeviceType()` tried to execute this command on such devices, it threw an uncaught exception that propagated to `getConnectedDevicesWithDetails()`, causing the entire device list to be empty.

Example device: `OR65Q21QC2D231900294` (Kona for arm64) returns `cmd: Can't find service: package` when running `adb shell pm list features`.

## Before Fix

```bash
$ mobile_list_available_devices
{"devices":[]}  # Empty despite 2 devices connected
```

## After Fix

```bash
$ mobile_list_available_devices
{"devices":[
  {"id":"OR65Q21QC2D231900294","name":"Kona for arm64","platform":"android",...},
  {"id":"172.28.56.32:5555","name":"LM-V600","platform":"android",...}
]}
```

## Testing

Tested locally with 2 Android devices connected (1 USB, 1 TCP/IP). Both devices are now correctly detected.