### PR TITLE
feat: replace --port with --listen flag and add optional auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,31 @@ Or add the standard config under `mcpServers` in your settings as shown above.
 
 [Read more in our wiki](https://github.com/mobile-next/mobile-mcp/wiki)! 🚀
 
+### SSE Server Mode
+
+By default, Mobile MCP runs over stdio. To start an SSE server instead, use the `--listen` flag:
+
+```bash
+npx @mobilenext/mobile-mcp@latest --listen 3000
+```
+
+This binds to `localhost:3000`. To bind to a specific interface:
+
+```bash
+npx @mobilenext/mobile-mcp@latest --listen 0.0.0.0:3000
+```
+
+Then configure your MCP client to connect to `http://<host>:3000/mcp`.
+
+#### Authorization
+
+To require Bearer token authorization on the SSE server, set the `MOBILEMCP_AUTH` environment variable:
+
+```bash
+MOBILEMCP_AUTH=my-secret-token npx @mobilenext/mobile-mcp@latest --listen 3000
+```
+
+When set, all requests must include the header `Authorization: Bearer my-secret-token`.
 
 ### 🛠️ How to Use 📝
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,21 @@ import { error } from "./logger";
 import express from "express";
 import { program } from "commander";
 
-const startSseServer = async (port: number) => {
+const startSseServer = async (host: string, port: number) => {
 	const app = express();
 	const server = createMcpServer();
+
+	const authToken = process.env.MOBILEMCP_AUTH;
+	if (authToken) {
+		app.use((req, res, next) => {
+			if (req.headers.authorization !== `Bearer ${authToken}`) {
+				res.status(401).json({ error: "Unauthorized" });
+				return;
+			}
+
+			next();
+		});
+	}
 
 	let transport: SSEServerTransport | null = null;
 
@@ -27,8 +39,8 @@ const startSseServer = async (port: number) => {
 		server.connect(transport);
 	});
 
-	app.listen(port, () => {
-		error(`mobile-mcp ${getAgentVersion()} sse server listening on http://localhost:${port}/mcp`);
+	app.listen(port, host, () => {
+		error(`mobile-mcp ${getAgentVersion()} sse server listening on http://${host}:${port}/mcp`);
 	});
 };
 
@@ -50,14 +62,26 @@ const startStdioServer = async () => {
 const main = async () => {
 	program
 		.version(getAgentVersion())
-		.option("--port <port>", "Start SSE server on this port")
+		.option("--listen <listen>", "Start SSE server on [host:]port")
 		.option("--stdio", "Start stdio server (default)")
 		.parse(process.argv);
 
 	const options = program.opts();
 
-	if (options.port) {
-		await startSseServer(+options.port);
+	if (options.listen) {
+		const listen = options.listen as string;
+		const lastColon = listen.lastIndexOf(":");
+		let host = "localhost";
+		let port: number;
+
+		if (lastColon > 0) {
+			host = listen.substring(0, lastColon);
+			port = +listen.substring(lastColon + 1);
+		} else {
+			port = +listen;
+		}
+
+		await startSseServer(host, port);
 	} else {
 		await startStdioServer();
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,16 +69,22 @@ const main = async () => {
 	const options = program.opts();
 
 	if (options.listen) {
-		const listen = options.listen as string;
+		const listen = (options.listen as string).trim();
 		const lastColon = listen.lastIndexOf(":");
 		let host = "localhost";
-		let port: number;
+		let rawPort: string;
 
 		if (lastColon > 0) {
 			host = listen.substring(0, lastColon);
-			port = +listen.substring(lastColon + 1);
+			rawPort = listen.substring(lastColon + 1);
 		} else {
-			port = +listen;
+			rawPort = listen;
+		}
+
+		const port = Number.parseInt(rawPort, 10);
+		if (!host || !rawPort || !Number.isInteger(port) || port < 1 || port > 65535) {
+			error(`Invalid --listen value "${listen}". Expected [host:]port with port 1-65535.`);
+			process.exit(1);
 		}
 
 		await startSseServer(host, port);


### PR DESCRIPTION
Rename --port to --listen accepting [host:]port format, defaulting to localhost instead of 0.0.0.0. Add optional Bearer token auth via MOBILEMCP_AUTH env variable. Document SSE server mode in README.