### PR TITLE
fix(install): validate path in mobile_install_app to prevent path traversal

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { validateOutputPath, validateFileExtension } from "./utils";
 
 const ALLOWED_SCREENSHOT_EXTENSIONS = [".png", ".jpg", ".jpeg"];
 const ALLOWED_RECORDING_EXTENSIONS = [".mp4"];
+const ALLOWED_INSTALL_EXTENSIONS = [".apk", ".ipa", ".zip", ".app"];
 
 interface MobilecliDevice {
 	id: string;
@@ -368,6 +369,8 @@ export const createMcpServer = (): McpServer => {
 		},
 		{ destructiveHint: true },
 		async ({ device, path }) => {
+			validateFileExtension(path, ALLOWED_INSTALL_EXTENSIONS, "mobile_install_app");
+			validateOutputPath(path);
 			const robot = getRobotFromDevice(device);
 			await robot.installApp(path);
 			return `Installed app from ${path}`;


### PR DESCRIPTION
## Summary

The `mobile_install_app` tool accepts a `path` parameter from the AI agent without any validation, unlike the `save_screenshot` and `start_screen_recording` tools which already use `validateFileExtension` and `validateOutputPath`. This means a prompt-injected agent could be directed to read or install files from arbitrary filesystem locations (CWE-22: Path Traversal).

This fix adds the same validation that already protects `save_screenshot` and `start_screen_recording` to `mobile_install_app`, making the security posture consistent across all file-accepting tools.

## Vulnerability Details

**CWE-22 (Improper Limitation of a Pathname to a Restricted Directory)**

- **Affected function:** `mobile_install_app` handler in `src/server.ts`
- **Data flow:** The `path` parameter from the MCP tool call flows directly into `robot.installApp(path)` with no path or extension validation.
- **Attack vector:** An attacker who achieves prompt injection against the AI agent (e.g., via a malicious webpage or document the agent is processing) could instruct the agent to call `mobile_install_app` with a traversal path like `../../../tmp/malicious.apk` or an absolute path outside the working directory.

### Proof of Concept

With the MCP server running, an AI agent could be prompted (via injection) to execute:

```json
{
  "tool": "mobile_install_app",
  "arguments": {
    "device": "emulator-5554",
    "path": "/etc/sensitive-data/payload.apk"
  }
}
```

Or with directory traversal:

```json
{
  "tool": "mobile_install_app",
  "arguments": {
    "device": "emulator-5554",
    "path": "../../../../tmp/attacker-controlled.apk"
  }
}
```

Before the fix, both calls pass through to `robot.installApp()` without any checks. After the fix, `validateOutputPath` rejects paths outside the current working directory and temp directory, and `validateFileExtension` rejects anything that isn't `.apk`, `.ipa`, `.zip`, or `.app`.

## Fix Description

The fix adds two lines to the `mobile_install_app` handler, calling the existing utility functions:

1. **`validateFileExtension(path, ALLOWED_INSTALL_EXTENSIONS, "mobile_install_app")`** — restricts accepted files to `.apk`, `.ipa`, `.zip`, and `.app`, preventing the tool from being used to access arbitrary file types.
2. **`validateOutputPath(path)`** — resolves the path (following symlinks) and checks it falls within allowed root directories (cwd or temp), preventing directory traversal.

A new constant `ALLOWED_INSTALL_EXTENSIONS` is added alongside the existing `ALLOWED_SCREENSHOT_EXTENSIONS` and `ALLOWED_RECORDING_EXTENSIONS`.

## Testing

- Verified that `validateOutputPath` resolves symlinks and checks against allowed roots (cwd, tmpdir) — paths like `../../../../etc/passwd` and absolute paths outside these roots are rejected with `ActionableError`.
- Verified that `validateFileExtension` checks the lowercased extension against the allowlist — files like `payload.sh` or `data.txt` are rejected.
- Confirmed the fix matches the exact pattern used by `save_screenshot` (line ~380) and `start_screen_recording` (line ~395), ensuring consistency.
- The change is 3 lines of code, all calling existing well-tested utility functions — no new logic is introduced.

## Adversarial Review

Before submitting, we considered whether this finding is practically exploitable. The MCP server runs locally and the attacker needs prompt injection to control the agent's tool calls. However, prompt injection is a well-documented and practical attack vector against AI agents, and the existing codebase already treats it as a threat — that's why `save_screenshot` and `start_screen_recording` have these exact validations. The `mobile_install_app` tool was simply missed. This fix closes the gap and makes the security model consistent.