### PR TITLE
ci: revert mcp-publisher to brew install without version pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,8 @@ jobs:
       env:
         VERSION: ${{ github.ref_name }}
       run: |
-        curl -fsSL https://github.com/modelcontextprotocol/registry/releases/download/v1.5.0/mcp-publisher_linux_amd64.tar.gz | tar xz -C /usr/local/bin mcp-publisher
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        brew install mcp-publisher
         mcp-publisher login github-oidc
         # patch version
         sed -i "s/{{VERSION}}/$VERSION/g" server.json


### PR DESCRIPTION
Direct curl download of v1.5.0 was not working. Revert to using Homebrew to install the latest mcp-publisher version.