### PR TITLE
feat: surface session URL after cloud device allocation

### DIFF
--- a/src/mobilecli.ts
+++ b/src/mobilecli.ts
@@ -2,6 +2,23 @@ import { existsSync } from "node:fs";
 import { dirname, join, sep } from "node:path";
 import { execFileSync, spawn, ChildProcess } from "node:child_process";
 
+export interface FleetAllocateResponse {
+	status: "ok" | "error";
+	data?: {
+		sessionId: string;
+		sessionUrl?: string;
+		state?: string;
+		device?: {
+			id: string;
+			name: string;
+			platform: string;
+			version: string;
+			model?: string;
+		};
+	};
+	error?: string;
+}
+
 export interface MobilecliDevicesOptions {
 	includeOffline?: boolean;
 	platform?: "ios" | "android";
@@ -115,8 +132,9 @@ export class Mobilecli {
 		return this.executeCommand(["fleet", "list-devices"]);
 	}
 
-	fleetAllocate(platform: "ios" | "android"): string {
-		return this.executeCommand(["fleet", "allocate", "--platform", platform]);
+	fleetAllocate(platform: "ios" | "android"): FleetAllocateResponse {
+		const raw = this.executeCommand(["fleet", "allocate", "--platform", platform, "--wait"]);
+		return JSON.parse(raw) as FleetAllocateResponse;
 	}
 
 	fleetRelease(deviceId: string): string {

--- a/src/server.ts
+++ b/src/server.ts
@@ -282,7 +282,7 @@ export const createMcpServer = (): McpServer => {
 		tool(
 			"mobile_allocate_fleet_device",
 			"Allocate Fleet Device",
-			"Reserve a device from the remote fleet",
+			"Reserve a real device from the mobilenext cloud fleet. Returns the device id and a link to the live session in the mobilenext dashboard.",
 			{
 				platform: z.enum(["ios", "android"]).describe("The platform to allocate a device for"),
 			},
@@ -290,7 +290,28 @@ export const createMcpServer = (): McpServer => {
 			async ({ platform }) => {
 				ensureMobilecliAvailable();
 				const result = mobilecli.fleetAllocate(platform);
-				return result;
+
+				if (result.status === "error" || !result.data) {
+					return `Failed to allocate device: ${result.error ?? "unknown error"}`;
+				}
+
+				const { sessionId, sessionUrl, device } = result.data;
+				const lines: string[] = [];
+
+				if (device) {
+					lines.push(`Allocated ${device.name} (${device.platform} ${device.version}, id: ${device.id})`);
+				} else {
+					lines.push(`Device allocation started (session: ${sessionId})`);
+				}
+
+				if (sessionUrl) {
+					lines.push(`Session: ${sessionUrl}`);
+				} else if (sessionId) {
+					lines.push(`Session: https://app.mobilenext.ai/sessions/${sessionId}`);
+				}
+
+				lines.push(`Use device id "${device?.id ?? ""}" with other mobile tools.`);
+				return lines.join("\n");
 			}
 		);
 


### PR DESCRIPTION
## Summary

- Adds `--wait` to the `fleet allocate` CLI call so the tool blocks until the device is fully ready before returning.
- Introduces a typed `FleetAllocateResponse` interface in `src/mobilecli.ts` (with `sessionId`, `sessionUrl`, `state`, and `device` fields) and updates `fleetAllocate` to return the parsed object instead of a raw JSON string.
- Updates the `mobile_allocate_fleet_device` MCP tool handler in `src/server.ts` to emit a human-readable message that includes the allocated device details and a direct link to the live session in the mobilenext dashboard (`https://app.mobilenext.ai/sessions/<sessionId>`). If `sessionUrl` is already present in the CLI response it is used directly; otherwise the URL is constructed from `sessionId`.
- Updates the tool description to clarify that it allocates a real cloud device and returns a dashboard link.

## Test plan

- [ ] Set `MOBILEFLEET_ENABLE=1` and invoke `mobile_allocate_fleet_device` with `platform: "ios"` or `"android"`.
- [ ] Confirm the tool response includes a line like `Allocated <name> (<platform> <version>, id: <id>)`, a `Session: https://app.mobilenext.ai/sessions/<id>` line, and the `Use device id` hint.
- [ ] Confirm the tool blocks until the device is ready (i.e. `--wait` is honoured by mobilecli).
- [ ] Confirm an error response from mobilecli surfaces as `Failed to allocate device: <reason>` instead of throwing.
- [ ] Run `npm run build` and confirm no TypeScript errors.