### PR TITLE
fix(ios): detect go-ios installed via npm (bare semver version)

### DIFF
--- a/src/ios.ts
+++ b/src/ios.ts
@@ -249,7 +249,7 @@ export class IosManager {
 			const output = execFileSync(getGoIosPath(), ["version"], { stdio: ["pipe", "pipe", "ignore"] }).toString();
 			const json: VersionCommandOutput = JSON.parse(output);
 			// go-ios installed via `npm install -g go-ios` reports a bare semver ("1.2.0"),
-			// while GitHub release builds report a "v"-prefixed tag ("v1.2.0"). Accept both.
+			// while GitHub release builds report a "v"-prefixed tag ("v1.2.0"). Accepting both.
 			return json.version !== undefined && (/^v?\d+\.\d+\.\d+/.test(json.version) || json.version === "local-build");
 		} catch (error) {
 			return false;

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -248,7 +248,9 @@ export class IosManager {
 		try {
 			const output = execFileSync(getGoIosPath(), ["version"], { stdio: ["pipe", "pipe", "ignore"] }).toString();
 			const json: VersionCommandOutput = JSON.parse(output);
-			return json.version !== undefined && (json.version.startsWith("v") || json.version === "local-build");
+			// go-ios installed via `npm install -g go-ios` reports a bare semver ("1.2.0"),
+			// while GitHub release builds report a "v"-prefixed tag ("v1.2.0"). Accept both.
+			return json.version !== undefined && (/^v?\d+\.\d+\.\d+/.test(json.version) || json.version === "local-build");
 		} catch (error) {
 			return false;
 		}

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -248,8 +248,6 @@ export class IosManager {
 		try {
 			const output = execFileSync(getGoIosPath(), ["version"], { stdio: ["pipe", "pipe", "ignore"] }).toString();
 			const json: VersionCommandOutput = JSON.parse(output);
-			// go-ios installed via `npm install -g go-ios` reports a bare semver ("1.2.0"),
-			// while GitHub release builds report a "v"-prefixed tag ("v1.2.0"). Accepting both.
 			return json.version !== undefined && (/^v?\d+\.\d+\.\d+/.test(json.version) || json.version === "local-build");
 		} catch (error) {
 			return false;


### PR DESCRIPTION
## Problem
Physical iOS devices are silently **not detected** when `go-ios` is installed the documented way — `npm install -g go-ios`.

## Root cause
`isGoIosInstalled()` in `src/ios.ts` accepts a version only if it starts with `v`:

```ts
return json.version !== undefined && (json.version.startsWith("v") || json.version === "local-build");
```

But the **npm** `go-ios` package reports a **bare semver**:

```console
$ ios version
{"version":"1.2.0"}      # npm package — no "v"
```

(GitHub release builds report `v1.2.0`, which is where the `startsWith("v")` assumption comes from.)

So `isGoIosInstalled()` returns `false`, and `listDevices()` / `listDevicesWithDetails()` log "go-ios is not installed" and skip the physical iPhone entirely — even though `ios list` works fine.

## Fix
Accept both `v`-prefixed and bare semver versions (still accepting `local-build`):

```ts
return json.version !== undefined && (/^v?\d+\.\d+\.\d+/.test(json.version) || json.version === "local-build");
```

## Validation
| `ios version` output | before | after |
|---|---|---|
| `1.2.0` (npm) | ❌ false | ✅ true |
| `v1.2.0` (release) | ✅ true | ✅ true |
| `local-build` | ✅ true | ✅ true |

## Repro
1. `npm install -g go-ios`
2. Connect a paired iOS 17+ device with a tunnel running.
3. Before: the device is missing from `mobile_list_available_devices`. After: it appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)