### PR TITLE
fix(android): correct device type classification and guard null hierarchy in getElementsOnScreen

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -363,6 +363,9 @@ export class AndroidRobot implements Robot {
 	public async getElementsOnScreen(): Promise<ScreenElement[]> {
 		const parsedXml = await this.getUiAutomatorXml();
 		const hierarchy = parsedXml.hierarchy;
+		if (!hierarchy?.node) {
+			throw new ActionableError("Screen hierarchy is unavailable — the device may be on the lock screen or in a restricted state");
+		}
 		const elements = this.collectElements(hierarchy.node);
 		return elements;
 	}
@@ -404,7 +407,7 @@ export class AndroidRobot implements Robot {
 
 	private escapeShellText(text: string): string {
 		// escape all shell special characters that could be used for injection
-		return text.replace(/[\\'"` \t\n\r|&;()<>{}[\]$*?]/g, "\\$&");
+		return text.replace(/[\\\'"\` \t\n\r|&;()<>{}[\]$*?]/g, "\\$&");
 	}
 
 	private async isDeviceKitInstalled(): Promise<boolean> {
@@ -565,6 +568,24 @@ export class AndroidDeviceManager {
 		}
 	}
 
+	private isEmulator(deviceId: string): boolean {
+		// ADB emulator serial numbers always start with "emulator-" (e.g. "emulator-5554").
+		// All other serials — alphanumeric USB serials or host:port for ADB-over-TLS/Wi-Fi —
+		// are physical devices.
+		if (deviceId.startsWith("emulator-")) {
+			return true;
+		}
+		// Secondary check via ro.boot.qemu.avd_name: non-empty only on QEMU-based emulators
+		try {
+			const avdName = execFileSync(getAdbPath(), ["-s", deviceId, "shell", "getprop", "ro.boot.qemu.avd_name"], {
+				timeout: 5000,
+			}).toString().trim();
+			return avdName !== "";
+		} catch {
+			return false;
+		}
+	}
+
 	public getConnectedDevices(): AndroidDevice[] {
 		try {
 			const names = execFileSync(getAdbPath(), ["devices"])
@@ -586,7 +607,7 @@ export class AndroidDeviceManager {
 		}
 	}
 
-	public getConnectedDevicesWithDetails(): Array<AndroidDevice & { version: string, name: string }> {
+	public getConnectedDevicesWithDetails(): Array<AndroidDevice & { version: string, name: string, isEmulator: boolean }> {
 		try {
 			const names = execFileSync(getAdbPath(), ["devices"])
 				.toString()
@@ -602,6 +623,7 @@ export class AndroidDeviceManager {
 				deviceType: this.getDeviceType(deviceId),
 				version: this.getDeviceVersion(deviceId),
 				name: this.getDeviceName(deviceId),
+				isEmulator: this.isEmulator(deviceId),
 			}));
 		} catch (error) {
 			console.error("Could not execute adb command, maybe ANDROID_HOME is not set?");

--- a/src/server.ts
+++ b/src/server.ts
@@ -235,7 +235,7 @@ export const createMcpServer = (): McpServer => {
 					id: device.deviceId,
 					name: device.name,
 					platform: "android",
-					type: "emulator",
+					type: device.isEmulator ? "emulator" : "real",
 					version: device.version,
 					state: "online",
 				});


### PR DESCRIPTION
## Summary

Two bugs found during testing with a physical Samsung SM-S926B (Android 16) over ADB-over-TLS:

### Bug 1: `mobile_list_available_devices` always reports `type: "emulator"` for Android devices

**Root cause** (`src/server.ts`): the loop that builds the device list hard-codes `type: "emulator"` for every Android entry, regardless of whether the device is a physical phone or an actual emulator.

**Fix**: Added `isEmulator()` to `AndroidDeviceManager` and `getConnectedDevicesWithDetails()` which feeds the corrected flag into `mobile_list_available_devices`. `isEmulator()` checks the ADB serial prefix (`emulator-` is the only prefix ADB ever assigns to QEMU-based emulators) and falls back to querying `ro.boot.qemu.avd_name` (non-empty only on emulators). All other serials — USB serials, `ip:port` from ADB-over-TLS — are physical devices.

### Bug 2: `getElementsOnScreen` crashes on lock screen / restricted XML

**Root cause** (`src/android.ts`): when `uiautomator dump` returns a restricted document (e.g. Samsung lock screen returns a minimal XML with no `<node>` children), `parsedXml.hierarchy` is `undefined`, and the immediately following `hierarchy.node` dereference throws `TypeError: Cannot read properties of undefined`.

**Fix**: Added a null guard before accessing `hierarchy.node`; throws `ActionableError` with a descriptive message instead of crashing.

Fixes #243

## Test plan

- [ ] Connect a physical Android device over USB and verify `mobile_list_available_devices` reports `type: "real"`
- [ ] Connect an Android emulator and verify `type: "emulator"`
- [ ] Connect a device over ADB-over-TLS (wireless debugging) and verify `type: "real"`
- [ ] Lock a physical device, call `mobile_list_elements_on_screen`, verify it returns an actionable error instead of crashing
- [ ] Unlock the device, call `mobile_list_elements_on_screen`, verify it returns elements normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)