### PR TITLE
chore: bump mobilewright to 0.0.48

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "commander": "14.0.0",
         "express": "5.1.0",
         "fast-xml-parser": "5.8.0",
-        "mobilewright": "0.0.45",
+        "mobilewright": "0.0.48",
         "qs": "^6.15.0",
         "zod": "^4.1.13",
         "zod-to-json-schema": "3.25.0"
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -386,6 +386,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -401,6 +404,9 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -418,6 +424,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -433,6 +442,9 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -450,6 +462,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -465,6 +480,9 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -482,6 +500,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -498,6 +519,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -513,6 +537,9 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -536,6 +563,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -557,6 +587,9 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -580,6 +613,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -601,6 +637,9 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -624,6 +663,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -646,6 +688,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -667,6 +712,9 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -816,12 +864,12 @@
       }
     },
     "node_modules/@mobilewright/core": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@mobilewright/core/-/core-0.0.45.tgz",
-      "integrity": "sha512-5wtqoG4AOAkr3u+Gegodvt6aeuF2Qe6Y5P0/p1HL8S1lFZ035MCD96TxE0zEDYNVaYyVLIaIAN59ri2O3Vi+JQ==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@mobilewright/core/-/core-0.0.48.tgz",
+      "integrity": "sha512-urR9LTwWRj9wCfPt8r4juQ9xXVL/hk6oQdJMi+pURm/8oX3L+vK43iHIG1YvrIkDhkAsZEhiSHZ9JRkPVujkjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mobilewright/protocol": "^0.0.45",
+        "@mobilewright/protocol": "^0.0.48",
         "debug": "^4.4.3",
         "playwright-core": "1.58.2",
         "sharp": "^0.34.5"
@@ -831,14 +879,14 @@
       }
     },
     "node_modules/@mobilewright/driver-mobilecli": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@mobilewright/driver-mobilecli/-/driver-mobilecli-0.0.45.tgz",
-      "integrity": "sha512-6v8hyjw3jgP6TeH4yqtKfXphr2sSIZj0BhD013Juk1//AYOdnGdltC2c0kbdeWUdqFB+K3G4Kc32fBVi7Gbfgg==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@mobilewright/driver-mobilecli/-/driver-mobilecli-0.0.48.tgz",
+      "integrity": "sha512-0+ErSymKE1JvC0BtUc/IjJExM89LVqoXVXazVEwMt+sxC3jU46TLhJ4EAuiLcoTVsRgQP5mqARV0cc+wWWOHdQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mobilewright/protocol": "^0.0.45",
+        "@mobilewright/protocol": "^0.0.48",
         "debug": "^4.4.3",
-        "mobilecli": "0.3.84",
+        "mobilecli": "0.3.85",
         "ws": "^8.18.0"
       },
       "engines": {
@@ -846,12 +894,12 @@
       }
     },
     "node_modules/@mobilewright/driver-mobilenext": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@mobilewright/driver-mobilenext/-/driver-mobilenext-0.0.45.tgz",
-      "integrity": "sha512-xXGuAb+ihezvtETr883mIlxreqECjRdXSL8jbFgK4VhJSk1/P+98zWlTMQRMVgwKOg9IKv+GG6JXSkTFD08YKw==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@mobilewright/driver-mobilenext/-/driver-mobilenext-0.0.48.tgz",
+      "integrity": "sha512-AqVVZjG/rjWwNL5F4aAn0ca/iyjMldTEY1/KJjUfTS6jfXXrMWWtcembYazxuCCObd444IFGmMAGDwtKDXZfxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mobilewright/protocol": "^0.0.45",
+        "@mobilewright/protocol": "^0.0.48",
         "debug": "^4.4.3",
         "ws": "^8.18.0"
       },
@@ -859,10 +907,68 @@
         "node": ">=18"
       }
     },
+    "node_modules/@mobilewright/inspector": {
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@mobilewright/inspector/-/inspector-0.0.48.tgz",
+      "integrity": "sha512-KsrfTnCIzQPXtkgtT1GtZG6+F4WhbZ+8dwl7T/wqfNA4/Iz7wQhQLGRRDrsoo1VCcBPyQRq1eg6btnhaxJEwvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mobilewright/core": "^0.0.48",
+        "@mobilewright/protocol": "^0.0.48",
+        "express": "^5.2.1",
+        "open": "^10.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mobilewright/inspector/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@mobilewright/protocol": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@mobilewright/protocol/-/protocol-0.0.45.tgz",
-      "integrity": "sha512-bArKuq4f7woi9ysBiRb1UWxKGHgZ+vwEH8WbpMYXXoEelDTpes0MZfMs4YNWisYSdwl4IRLiHzseQqMkJDPePQ==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@mobilewright/protocol/-/protocol-0.0.48.tgz",
+      "integrity": "sha512-1XzxMAKR+idIycZAl3/PhDH8V/f/nZv9qFjY0NFlCLEBTTwHRQgvVCXfeFneS+jQD0RXk8OnQmee4vdmcoauwg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -1807,6 +1913,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2237,6 +2358,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -2253,6 +2402,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -3780,6 +3941,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3846,6 +4022,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-map": {
@@ -4050,6 +4244,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -4377,26 +4586,28 @@
       }
     },
     "node_modules/mobilecli": {
-      "version": "0.3.84",
-      "resolved": "https://registry.npmjs.org/mobilecli/-/mobilecli-0.3.84.tgz",
-      "integrity": "sha512-TOyyavbO5mtzMlJ6vdAZbtjgH4GM392biOxiKDV9s4lMPzA0TSUphBZVCOKsCN03kotNJA2JytdY500H6iHvJw==",
+      "version": "0.3.85",
+      "resolved": "https://registry.npmjs.org/mobilecli/-/mobilecli-0.3.85.tgz",
+      "integrity": "sha512-Sr799t3YgF8Zu5kJH3baGh4m8GQ47MVDbGJ/odfUgug7esh4c+dBdLIyDZ/+ZzacJ6H9n/B8lXq/oAxoTJHvjw==",
       "license": "MIT",
       "bin": {
         "mobilecli": "index.js"
       }
     },
     "node_modules/mobilewright": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/mobilewright/-/mobilewright-0.0.45.tgz",
-      "integrity": "sha512-z9QJRtiGBax310zAhoMBvULm8uKnVPcVn+ELhII1E1LLPJDzoGYhFcVLfAzS8ela99KqYRKFS0D75ayCpENhFQ==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/mobilewright/-/mobilewright-0.0.48.tgz",
+      "integrity": "sha512-+3ba9bYh/SvHjPOHDtkK1Lg/hDr2AW43RaJExGbSN7QssEd3qKGel3l87WLzHGVVS8/nUWQhArZ9wplVampHPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mobilewright/core": "^0.0.45",
-        "@mobilewright/driver-mobilecli": "^0.0.45",
-        "@mobilewright/driver-mobilenext": "^0.0.45",
-        "@mobilewright/protocol": "^0.0.45",
+        "@mobilewright/core": "^0.0.48",
+        "@mobilewright/driver-mobilecli": "^0.0.48",
+        "@mobilewright/driver-mobilenext": "^0.0.48",
+        "@mobilewright/inspector": "^0.0.48",
+        "@mobilewright/protocol": "^0.0.48",
         "commander": "^14.0.3",
         "debug": "^4.4.3",
+        "open": "^10.2.0",
         "playwright": "1.58.2",
         "ws": "^8.18.0"
       },
@@ -4562,6 +4773,24 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -5020,6 +5249,18 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -6125,6 +6366,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xml-naming": {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "commander": "14.0.0",
     "express": "5.1.0",
     "fast-xml-parser": "5.8.0",
+    "mobilewright": "0.0.48",
     "qs": "^6.15.0",
     "zod": "^4.1.13",
-    "zod-to-json-schema": "3.25.0",
-    "mobilewright": "0.0.45"
+    "zod-to-json-schema": "3.25.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",


### PR DESCRIPTION
Updates the `mobilewright` dependency from 0.0.45 to 0.0.48.