### PR TITLE
fix: avoid DeviceKit agent race in mobile_take_screenshot

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -648,8 +648,12 @@ export const createMcpServer = (): McpServer => {
 		async ({ device }) => {
 			try {
 				const robot = getRobotFromDevice(device);
-				const screenSize = await robot.getScreenSize();
 
+				// Take the screenshot in a single mobilecli invocation. Calling
+				// getScreenSize() first (a separate mobilecli process) starts the
+				// DeviceKit/WebDriverAgent runner, then getScreenshot() cannot see
+				// that agent process and tries to start a second one — which races
+				// and times out with "timed out waiting for WebDriverAgent to be ready".
 				let screenshot = await robot.getScreenshot();
 				let mimeType = "image/png";
 
@@ -664,7 +668,11 @@ export const createMcpServer = (): McpServer => {
 					trace("Image scaling is available, resizing screenshot");
 					const image = Image.fromBuffer(screenshot);
 					const beforeSize = screenshot.length;
-					screenshot = image.resize(Math.floor(pngSize.width / screenSize.scale))
+					// Cap width for the LLM payload instead of pngWidth/screenScale,
+					// which required the extra getScreenSize() call above.
+					const maxWidth = 512;
+					const targetWidth = Math.min(pngSize.width, maxWidth);
+					screenshot = image.resize(targetWidth)
 						.jpeg({ quality: 75 })
 						.toBuffer();
 


### PR DESCRIPTION
## Summary

`mobile_take_screenshot` was calling `getScreenSize()` then `getScreenshot()` as two separate `mobilecli` processes. On iOS Simulator, each invocation that needs the DeviceKit agent tries to start it:

1. `device info` starts the agent and succeeds
2. `screenshot` cannot find that agent process (tracking is per-process), starts a second runner, races the first, and times out with `timed out waiting for WebDriverAgent to be ready`

Single-call tools like `mobile_list_elements_on_screen` / `mobilecli screenshot` alone work fine on the same simulator.

## Fix

- Take the screenshot in one `mobilecli` invocation only
- When scaling is available, resize to a max width of 512px (LLM-friendly) instead of `pngWidth / screenScale`, which required the extra `getScreenSize()` call

## Test plan

- [ ] Boot an iOS Simulator with DeviceKit agent installed (`mobilecli agent install`)
- [ ] Run `mobile_take_screenshot` via MCP — should succeed without the WDA timeout
- [ ] Confirm `mobile_list_elements_on_screen` still works
- [ ] Optionally reproduce the old failure: `mobilecli device info` immediately followed by `mobilecli screenshot` still races (expected; this PR only fixes the MCP tool)