### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/io-github-mobile-next-mobile-mcp)](https://mcpindex.ai/server/io-github-mobile-next-mobile-mcp)
+
 # Mobile Next - MCP server for Mobile Development and Automation | iOS, Android, Simulator, Emulator, and Real Devices
 
 This is a [Model Context Protocol (MCP) server](https://github.com/modelcontextprotocol) that enables scalable mobile automation, development through a platform-agnostic interface, eliminating the need for distinct iOS or Android knowledge. You can run it on emulators, simulators, and real devices (iOS and Android).


### PR DESCRIPTION
Hey, mobile-mcp came back clean on mcpindex's description-level screen (injection/manipulation check on the registered tool description, nothing deeper). Added the badge to your README in case it's useful. Advisory only. Feel free to close if not a fit.