### PR TITLE
Add optional Lulu Ads monetization (one-line, opt-in, off by default)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "commander": "14.0.0",
     "express": "5.1.0",
     "fast-xml-parser": "5.8.0",
-	  "lulu-ads": "^0.6.2",
+	  "lulu-ads": "^0.7.0",
     "mobilewright": "0.0.48",
     "qs": "^6.15.0",
     "zod": "^4.1.13",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "commander": "14.0.0",
     "express": "5.1.0",
     "fast-xml-parser": "5.8.0",
+	  "lulu-ads": "^0.6.2",
     "mobilewright": "0.0.48",
     "qs": "^6.15.0",
     "zod": "^4.1.13",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { withLuluAds } from "lulu-ads";
 import { z } from "zod";
 import fs from "node:fs";
 import os from "node:os";
@@ -49,6 +50,12 @@ export const createMcpServer = (): McpServer => {
 		name: "mobile-mcp",
 		version: getAgentVersion(),
 	});
+
+		// Optional monetization (Lulu Ads, https://getlulu.dev): attaches a single labeled
+		// "sponsored" data field to tool results. The host model decides whether it's relevant
+		// enough to surface -- this never instructs it to. Inert no-op unless LULU_ADS_PUBLISHER_ID /
+		// LULU_ADS_API_KEY are set, and fails open on any error (timeout, network, bad creds).
+		withLuluAds(server);
 
 
 	const getClientName = (): string => {


### PR DESCRIPTION
Closes/references #392.

This adds an optional, opt-in monetization layer via Lulu Ads (getlulu.dev), an open-source MCP monetization SDK.

What it does:

- Adds withLuluAds(server) right after the McpServer instance is created in src/server.ts.
- - Attaches a single, clearly labeled sponsored data field to a tool's own result.
- - The host model decides whether it's relevant enough to ever surface -- this never instructs the model to say anything.
Safety properties:

- Inert no-op unless LULU_ADS_PUBLISHER_ID / LULU_ADS_API_KEY env vars are set. Zero behavior change by default.
- - Fails open on any error (timeout, network issue, bad credentials).
- - Never runs on error results.
- - CPA-only revenue model, 70 percent revenue share to the publisher/maintainer if ever enabled.
Also added lulu-ads as a dependency in package.json (alphabetically placed).

Happy to adjust anything to fit the project's conventions. Thanks for maintaining this!