### PR TITLE
docs: update changelog for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.0.0](https://github.com/mobile-next/mobile-mcp/releases/tag/1.0.0) (2026-08-02)
+
+**BREAKING CHANGE**
+Starting from version 1.0.0, mobilecli is used as the backend, instead of the old typescript code.
+If you see any regression, please let us know immediately through a github issue (https://github.com/mobile-next/mobile-mcp/issues)
+You can use environment variable `MOBILEMCP_LEGACY_ROBOT` to force old implementation. Legacy code will be removed 1 month from this notice.
+
+* Feat: Route devices through mobilecli by default ([#396](https://github.com/mobile-next/mobile-mcp/pull/396))
+
 ## [0.0.62](https://github.com/mobile-next/mobile-mcp/releases/tag/0.0.62) (2026-07-11)
 * iOS: Support "-" (hyphen) in iOS bundle identifier ([#377](https://github.com/mobile-next/mobile-mcp/pull/377)), thanks to [@TsurP](https://github.com/TsurP)
 * Fix: Properly resolve symlinks for paths allowlist ([#377](https://github.com/mobile-next/mobile-mcp/pull/377)), thanks to [@TsurP](https://github.com/TsurP)


### PR DESCRIPTION
## Summary
- Add the 1.0.0 changelog entry, marking the switch to mobilecli as the default backend as a breaking change (`MOBILEMCP_LEGACY_ROBOT` remains available as a fallback for one month)
- Credits #396 (route devices through mobilecli by default)

## Test plan
- [ ] Confirm version bump to 1.0.0 is intended before merging/tagging