### PR TITLE
feat: improve remote device MCP tools and add cloud login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -405,9 +405,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -423,9 +420,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -443,9 +437,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -461,9 +452,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -481,9 +469,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -499,9 +484,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -519,9 +501,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -538,9 +517,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -556,9 +532,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -582,9 +555,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -606,9 +576,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -632,9 +599,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -656,9 +620,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -682,9 +643,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -707,9 +665,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -731,9 +686,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3722,9 +3674,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3848,9 +3800,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/src/mobilecli.ts
+++ b/src/mobilecli.ts
@@ -36,7 +36,7 @@ export interface MobilecliDevicesOptions {
 
 export interface MobilecliRemoteAllocateOptions {
 	platform: "ios" | "android";
-	name?: string[];
+	name?: string;
 	version?: string[];
 	type?: "real";
 	wait?: boolean;
@@ -175,8 +175,8 @@ export class Mobilecli {
 	remoteAllocate(options: MobilecliRemoteAllocateOptions): string {
 		const args = ["remote", "allocate", "--platform", options.platform];
 
-		for (const name of options.name ?? []) {
-			args.push("--name", name);
+		if (options.name) {
+			args.push("--name", options.name);
 		}
 
 		for (const version of options.version ?? []) {

--- a/src/mobilecli.ts
+++ b/src/mobilecli.ts
@@ -34,6 +34,15 @@ export interface MobilecliDevicesOptions {
 	type?: "real" | "emulator" | "simulator";
 }
 
+export interface MobilecliRemoteAllocateOptions {
+	platform: "ios" | "android";
+	name?: string[];
+	version?: string[];
+	type?: "real";
+	wait?: boolean;
+	timeoutSeconds?: number;
+}
+
 export interface MobilecliDeviceProvider {
 	type: string; // e.g. "mobilefleet" for remote devices
 	allocationId?: string;
@@ -58,6 +67,7 @@ export interface MobilecliDevicesResponse {
 
 const TIMEOUT = 30000;
 const MAX_BUFFER_SIZE = 1024 * 1024 * 8;
+const DEFAULT_ALLOCATE_TIMEOUT_SECONDS = 900; // matches mobilecli's own "remote allocate --wait" default
 
 export class Mobilecli {
 	private path: string | null = null;
@@ -71,9 +81,14 @@ export class Mobilecli {
 		return this.path;
 	}
 
-	public executeCommand(args: string[]): string {
+	public executeCommand(args: string[], timeoutMs?: number): string {
 		const path = this.getPath();
-		return execFileSync(path, args, { encoding: "utf8" }).toString().trim();
+		const options: { encoding: "utf8"; timeout?: number } = { encoding: "utf8" };
+		if (timeoutMs !== undefined) {
+			options.timeout = timeoutMs;
+		}
+
+		return execFileSync(path, args, options).toString().trim();
 	}
 
 	public spawnCommand(args: string[]): ChildProcess {
@@ -146,12 +161,46 @@ export class Mobilecli {
 		}
 	}
 
+	spawnRemoteLogin(): ChildProcess {
+		const binaryPath = this.getPath();
+		return spawn(binaryPath, ["auth", "login", "--provider", "mobilenext"], {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+	}
+
 	remoteListDevices(): string {
 		return this.executeCommand(["remote", "list-devices"]);
 	}
 
-	remoteAllocate(platform: "ios" | "android"): string {
-		return this.executeCommand(["remote", "allocate", "--platform", platform]);
+	remoteAllocate(options: MobilecliRemoteAllocateOptions): string {
+		const args = ["remote", "allocate", "--platform", options.platform];
+
+		for (const name of options.name ?? []) {
+			args.push("--name", name);
+		}
+
+		for (const version of options.version ?? []) {
+			args.push("--version", version);
+		}
+
+		if (options.type) {
+			args.push("--type", options.type);
+		}
+
+		if (options.wait) {
+			args.push("--wait");
+		}
+
+		if (options.timeoutSeconds !== undefined) {
+			args.push("--timeout", String(options.timeoutSeconds));
+		}
+
+		// only "--wait" makes this call block for as long as mobilecli's own allocation timeout
+		const execTimeoutMs = options.wait
+			? (options.timeoutSeconds ?? DEFAULT_ALLOCATE_TIMEOUT_SECONDS) * 1000 + 5000
+			: undefined;
+
+		return this.executeCommand(args, execTimeoutMs);
 	}
 
 	remoteRelease(deviceId: string): string {

--- a/src/server.ts
+++ b/src/server.ts
@@ -310,140 +310,138 @@ export const createMcpServer = (): McpServer => {
 		}
 	);
 
-	if (process.env.MOBILEFLEET_ENABLE === "1") {
-		tool(
-			"mobile_login_to_cloud_provider",
-			"Login to Cloud Provider",
-			"Start authenticating this machine with the remote device cloud provider. This is required once before mobile_list_remote_devices or mobile_allocate_remote_device will work; if either of those fails with an authentication error, call this tool and then retry. " +
-			"This starts a browser-based device-code login and returns quickly with a URL and a one-time code - it does NOT wait for the login to complete. Show the URL and code to the user verbatim and ask them to open the URL and enter the code in their own browser. " +
-			"The login keeps running in the background after this tool returns; once the user confirms they've completed it, retry the remote devices tool that originally failed. " +
-			"Only call this after the user has explicitly asked to connect to, log into, or use remote/cloud devices - never call it speculatively, since it interrupts the user to act in their browser.",
-			{},
-			{},
-			async ({}) => {
-				ensureMobilecliAvailable();
+	tool(
+		"mobile_login_to_cloud_provider",
+		"Login to Cloud Provider",
+		"Start authenticating this machine with the remote device cloud provider. This is required once before mobile_list_remote_devices or mobile_allocate_remote_device will work; if either of those fails with an authentication error, call this tool and then retry. " +
+		"This starts a browser-based device-code login and returns quickly with a URL and a one-time code - it does NOT wait for the login to complete. Show the URL and code to the user verbatim and ask them to open the URL and enter the code in their own browser. " +
+		"The login keeps running in the background after this tool returns; once the user confirms they've completed it, retry the remote devices tool that originally failed. " +
+		"Only call this after the user has explicitly asked to connect to, log into, or use remote/cloud devices - never call it speculatively, since it interrupts the user to act in their browser.",
+		{},
+		{},
+		async ({}) => {
+			ensureMobilecliAvailable();
 
-				const child = mobilecli.spawnRemoteLogin();
-				activeLoginProcesses.push(child);
+			const child = mobilecli.spawnRemoteLogin();
+			activeLoginProcesses.push(child);
 
-				const forget = () => {
-					const index = activeLoginProcesses.indexOf(child);
-					if (index !== -1) {
-						activeLoginProcesses.splice(index, 1);
+			const forget = () => {
+				const index = activeLoginProcesses.indexOf(child);
+				if (index !== -1) {
+					activeLoginProcesses.splice(index, 1);
+				}
+			};
+
+			return new Promise<string>((resolve, reject) => {
+				let output = "";
+				let settled = false;
+
+				const promptTimeout = setTimeout(() => {
+					if (!settled) {
+						settled = true;
+						reject(new ActionableError(`Timed out waiting for the login prompt from mobilecli. Output so far: ${output.trim() || "(none)"}`));
 					}
-				};
+				}, LOGIN_PROMPT_TIMEOUT_MS);
 
-				return new Promise<string>((resolve, reject) => {
-					let output = "";
-					let settled = false;
+				child.stdout?.on("data", (chunk: Buffer) => {
+					output += chunk.toString();
 
-					const promptTimeout = setTimeout(() => {
-						if (!settled) {
-							settled = true;
-							reject(new ActionableError(`Timed out waiting for the login prompt from mobilecli. Output so far: ${output.trim() || "(none)"}`));
+					if (!settled && output.includes("Waiting for authorization")) {
+						settled = true;
+						clearTimeout(promptTimeout);
+
+						const urlMatch = output.match(/(https?:\/\/\S+)/);
+						const codeMatch = output.match(/enter the code:\s*(\S+)/i);
+
+						if (urlMatch && codeMatch) {
+							resolve(`Authentication to mobilenext.ai started, please open ${urlMatch[1]} and enter the code: ${codeMatch[1]}`);
+						} else {
+							resolve(`Authentication started, please check the output: ${output.trim()}`);
 						}
-					}, LOGIN_PROMPT_TIMEOUT_MS);
-
-					child.stdout?.on("data", (chunk: Buffer) => {
-						output += chunk.toString();
-
-						if (!settled && output.includes("Waiting for authorization")) {
-							settled = true;
-							clearTimeout(promptTimeout);
-
-							const urlMatch = output.match(/(https?:\/\/\S+)/);
-							const codeMatch = output.match(/enter the code:\s*(\S+)/i);
-
-							if (urlMatch && codeMatch) {
-								resolve(`Authentication to mobilenext.ai started, please open ${urlMatch[1]} and enter the code: ${codeMatch[1]}`);
-							} else {
-								resolve(`Authentication started, please check the output: ${output.trim()}`);
-							}
-						}
-					});
-
-					child.stderr?.on("data", (chunk: Buffer) => {
-						output += chunk.toString();
-					});
-
-					child.on("error", (err: Error) => {
-						forget();
-						if (!settled) {
-							settled = true;
-							clearTimeout(promptTimeout);
-							reject(new ActionableError(`Failed to start login: ${err.message}`));
-						}
-					});
-
-					child.on("exit", (code: number | null) => {
-						forget();
-						if (!settled) {
-							settled = true;
-							clearTimeout(promptTimeout);
-							reject(new ActionableError(`mobilecli auth login exited early (code ${code}). Output: ${output.trim() || "(none)"}`));
-						}
-					});
+					}
 				});
-			}
-		);
 
-		tool(
-			"mobile_list_remote_devices",
-			"List Remote Devices",
-			"List the catalog of device models (make, platform, OS version) available to reserve from the remote cloud device fleet. " +
-			"This is different from mobile_list_available_devices, which lists real devices and simulators/emulators already connected to this local machine and ready to use immediately at no cost. " +
-			"Remote devices live in a shared cloud fleet: they are not usable until reserved with mobile_allocate_remote_device, and reserving one may be a limited/billed resource. " +
-			"Requires mobile_login_to_cloud_provider to have been called first; if this fails with an authentication error, call that tool then retry.",
-			{},
-			{ readOnlyHint: true },
-			async ({}) => {
-				ensureMobilecliAvailable();
-				const result = mobilecli.remoteListDevices();
-				return result;
-			}
-		);
+				child.stderr?.on("data", (chunk: Buffer) => {
+					output += chunk.toString();
+				});
 
-		tool(
-			"mobile_allocate_remote_device",
-			"Allocate Remote Device",
-			"Reserve a physical device from the remote cloud fleet for exclusive use, returning a device identifier usable with the other mobile_* tools. " +
-			"Unlike local devices, a remote device is a shared and potentially billed resource borrowed for the session - only call this after the user has explicitly asked to use a remote/cloud device, never speculatively or as a fallback when a local device isn't found. " +
-			"Requires mobile_login_to_cloud_provider to have been called first; if this fails with an authentication error, call that tool then retry. " +
-			"Use mobile_list_remote_devices first to see which names and versions actually exist in the fleet before filtering by them. " +
-			"Release the device with mobile_release_remote_device once the whole task is finished - releasing wipes the device's state, so do not release and reallocate between steps of the same task just to be tidy.",
-			{
-				platform: z.enum(["ios", "android"]).describe("The platform to allocate a device for"),
-				name: z.array(z.string()).optional().describe("Filter by device name/model. Supports a trailing * for prefix match (e.g. \"iPhone*\"), or an exact name (e.g. \"iPhone 16\"). Multiple values are ANDed together."),
-				version: z.array(z.string()).optional().describe("Filter by OS version. Supports comparison prefixes >=, >, <=, < (e.g. \">=18\"), or an exact version (e.g. \"18.6.2\"). Multiple values are ANDed together."),
-				type: z.enum(["real"]).optional().describe("Device type filter. Currently only \"real\" (physical devices) is supported by the fleet."),
-				wait: z.boolean().optional().describe("If true, block until the device has finished allocating and is ready to use, up to timeoutSeconds. If false/omitted, this returns as soon as the reservation is made, but the device may not be immediately ready."),
-				timeoutSeconds: z.coerce.number().optional().describe("Seconds to wait for allocation when wait is true. Defaults to 900 (15 minutes). Only relevant when wait is true."),
-			},
-			{ destructiveHint: true },
-			async ({ platform, name, version, type, wait, timeoutSeconds }) => {
-				ensureMobilecliAvailable();
-				const result = mobilecli.remoteAllocate({ platform, name, version, type, wait, timeoutSeconds });
-				return result;
-			}
-		);
+				child.on("error", (err: Error) => {
+					forget();
+					if (!settled) {
+						settled = true;
+						clearTimeout(promptTimeout);
+						reject(new ActionableError(`Failed to start login: ${err.message}`));
+					}
+				});
 
-		tool(
-			"mobile_release_remote_device",
-			"Release Remote Device",
-			"Release a device previously reserved with mobile_allocate_remote_device back to the remote cloud fleet so it becomes available to others. " +
-			"Releasing is destructive to the device's state: apps installed, files pushed, and any other changes made during this session are lost, and a later mobile_allocate_remote_device call may take time and could return a different physical unit. " +
-			"Only release once the whole task is finished - if there is more work to do on the same device shortly, keep holding it rather than releasing and reallocating.",
-			{
-				device: z.string().describe("The device identifier to release back to the remote fleet"),
-			},
-			{ destructiveHint: true },
-			async ({ device }) => {
-				ensureMobilecliAvailable();
-				const result = mobilecli.remoteRelease(device);
-				return result;
-			}
-		);
-	}
+				child.on("exit", (code: number | null) => {
+					forget();
+					if (!settled) {
+						settled = true;
+						clearTimeout(promptTimeout);
+						reject(new ActionableError(`mobilecli auth login exited early (code ${code}). Output: ${output.trim() || "(none)"}`));
+					}
+				});
+			});
+		}
+	);
+
+	tool(
+		"mobile_list_remote_devices",
+		"List Remote Devices",
+		"List the catalog of device models (make, platform, OS version) available to reserve from the remote cloud device fleet. " +
+		"This is different from mobile_list_available_devices, which lists real devices and simulators/emulators already connected to this local machine and ready to use immediately at no cost. " +
+		"Remote devices live in a shared cloud fleet: they are not usable until reserved with mobile_allocate_remote_device, and reserving one may be a limited/billed resource. " +
+		"Requires mobile_login_to_cloud_provider to have been called first; if this fails with an authentication error, call that tool then retry.",
+		{},
+		{ readOnlyHint: true },
+		async ({}) => {
+			ensureMobilecliAvailable();
+			const result = mobilecli.remoteListDevices();
+			return result;
+		}
+	);
+
+	tool(
+		"mobile_allocate_remote_device",
+		"Allocate Remote Device",
+		"Reserve a physical device from the remote cloud fleet for exclusive use, returning a device identifier usable with the other mobile_* tools. " +
+		"Unlike local devices, a remote device is a shared and billed resource borrowed for the session - only call this after the user has explicitly asked to use a remote/cloud device, never speculatively or as a fallback when a local device isn't found. " +
+		"Requires mobile_login_to_cloud_provider to have been called first; if this fails with an authentication error, call that tool then retry. " +
+		"Use mobile_list_remote_devices first to see which names and versions actually exist in the fleet before filtering by them. " +
+		"Release the device with mobile_release_remote_device once the whole task is finished - releasing wipes the device's state, so do not release and reallocate between steps of the same task just to be tidy.",
+		{
+			platform: z.enum(["ios", "android"]).describe("The platform to allocate a device for"),
+			name: z.array(z.string()).optional().describe("Filter by device name/model. Supports a trailing * for prefix match (e.g. \"iPhone*\"), or an exact name (e.g. \"iPhone 16\"). Multiple values are ANDed together."),
+			version: z.array(z.string()).optional().describe("Filter by OS version. Supports comparison prefixes >=, >, <=, < (e.g. \">=18\"), or an exact version (e.g. \"18.6.2\"). Multiple values are ANDed together."),
+			type: z.enum(["real"]).optional().describe("Device type filter. Currently only \"real\" (physical devices) is supported by the fleet."),
+			wait: z.boolean().optional().describe("If true, block until the device has finished allocating and is ready to use, up to timeoutSeconds. If false/omitted, this returns as soon as the reservation is made, but the device may not be immediately ready."),
+			timeoutSeconds: z.coerce.number().optional().describe("Seconds to wait for allocation when wait is true. Defaults to 900 (15 minutes). Only relevant when wait is true."),
+		},
+		{ destructiveHint: true },
+		async ({ platform, name, version, type, wait, timeoutSeconds }) => {
+			ensureMobilecliAvailable();
+			const result = mobilecli.remoteAllocate({ platform, name, version, type, wait, timeoutSeconds });
+			return result;
+		}
+	);
+
+	tool(
+		"mobile_release_remote_device",
+		"Release Remote Device",
+		"Release a device previously reserved with mobile_allocate_remote_device back to the remote cloud fleet so it becomes available to others. " +
+		"Releasing is destructive to the device's state: apps installed, files pushed, and any other changes made during this session are lost, and a later mobile_allocate_remote_device call may take time and could return a different physical unit. " +
+		"Only release once the whole task is finished - if there is more work to do on the same device shortly, keep holding it rather than releasing and reallocating.",
+		{
+			device: z.string().describe("The device identifier to release back to the remote fleet"),
+		},
+		{ destructiveHint: true },
+		async ({ device }) => {
+			ensureMobilecliAvailable();
+			const result = mobilecli.remoteRelease(device);
+			return result;
+		}
+	);
 
 	tool(
 		"mobile_list_apps",

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { validateOutputPath, validateFileExtension } from "./utils";
 
 const ALLOWED_SCREENSHOT_EXTENSIONS = [".png", ".jpg", ".jpeg"];
 const ALLOWED_RECORDING_EXTENSIONS = [".mp4"];
+const LOGIN_PROMPT_TIMEOUT_MS = 15000;
 
 interface MobilecliDevice {
 	id: string;
@@ -151,6 +152,7 @@ export const createMcpServer = (): McpServer => {
 	const mobilecli = new Mobilecli();
 	const activeRecordings = new Map<string, ActiveRecording>();
 	const agentVerifiedSimulators = new Set<string>();
+	const activeLoginProcesses: ChildProcess[] = [];
 	posthog("launch", {}).then();
 
 	const ensureMobilecliAvailable = (): void => {
@@ -222,7 +224,8 @@ export const createMcpServer = (): McpServer => {
 	tool(
 		"mobile_list_available_devices",
 		"List Devices",
-		"List all available devices. This includes both physical mobile devices and mobile simulators and emulators. It returns both Android and iOS devices.",
+		"List all available devices. This includes both physical mobile devices and mobile simulators and emulators. It returns both Android and iOS devices. " +
+		"These are local devices already connected to this machine, ready to use immediately at no cost - for devices from the shared remote cloud fleet, use mobile_list_remote_devices instead.",
 		{},
 		{ readOnlyHint: true },
 		async ({}, telemetry) => {
@@ -309,9 +312,88 @@ export const createMcpServer = (): McpServer => {
 
 	if (process.env.MOBILEFLEET_ENABLE === "1") {
 		tool(
+			"mobile_login_to_cloud_provider",
+			"Login to Cloud Provider",
+			"Start authenticating this machine with the remote device cloud provider. This is required once before mobile_list_remote_devices or mobile_allocate_remote_device will work; if either of those fails with an authentication error, call this tool and then retry. " +
+			"This starts a browser-based device-code login and returns quickly with a URL and a one-time code - it does NOT wait for the login to complete. Show the URL and code to the user verbatim and ask them to open the URL and enter the code in their own browser. " +
+			"The login keeps running in the background after this tool returns; once the user confirms they've completed it, retry the remote devices tool that originally failed. " +
+			"Only call this after the user has explicitly asked to connect to, log into, or use remote/cloud devices - never call it speculatively, since it interrupts the user to act in their browser.",
+			{},
+			{},
+			async ({}) => {
+				ensureMobilecliAvailable();
+
+				const child = mobilecli.spawnRemoteLogin();
+				activeLoginProcesses.push(child);
+
+				const forget = () => {
+					const index = activeLoginProcesses.indexOf(child);
+					if (index !== -1) {
+						activeLoginProcesses.splice(index, 1);
+					}
+				};
+
+				return new Promise<string>((resolve, reject) => {
+					let output = "";
+					let settled = false;
+
+					const promptTimeout = setTimeout(() => {
+						if (!settled) {
+							settled = true;
+							reject(new ActionableError(`Timed out waiting for the login prompt from mobilecli. Output so far: ${output.trim() || "(none)"}`));
+						}
+					}, LOGIN_PROMPT_TIMEOUT_MS);
+
+					child.stdout?.on("data", (chunk: Buffer) => {
+						output += chunk.toString();
+
+						if (!settled && output.includes("Waiting for authorization")) {
+							settled = true;
+							clearTimeout(promptTimeout);
+
+							const urlMatch = output.match(/(https?:\/\/\S+)/);
+							const codeMatch = output.match(/enter the code:\s*(\S+)/i);
+
+							if (urlMatch && codeMatch) {
+								resolve(`Authentication to mobilenext.ai started, please open ${urlMatch[1]} and enter the code: ${codeMatch[1]}`);
+							} else {
+								resolve(`Authentication started, please check the output: ${output.trim()}`);
+							}
+						}
+					});
+
+					child.stderr?.on("data", (chunk: Buffer) => {
+						output += chunk.toString();
+					});
+
+					child.on("error", (err: Error) => {
+						forget();
+						if (!settled) {
+							settled = true;
+							clearTimeout(promptTimeout);
+							reject(new ActionableError(`Failed to start login: ${err.message}`));
+						}
+					});
+
+					child.on("exit", (code: number | null) => {
+						forget();
+						if (!settled) {
+							settled = true;
+							clearTimeout(promptTimeout);
+							reject(new ActionableError(`mobilecli auth login exited early (code ${code}). Output: ${output.trim() || "(none)"}`));
+						}
+					});
+				});
+			}
+		);
+
+		tool(
 			"mobile_list_remote_devices",
 			"List Remote Devices",
-			"List devices available in the remote fleet",
+			"List the catalog of device models (make, platform, OS version) available to reserve from the remote cloud device fleet. " +
+			"This is different from mobile_list_available_devices, which lists real devices and simulators/emulators already connected to this local machine and ready to use immediately at no cost. " +
+			"Remote devices live in a shared cloud fleet: they are not usable until reserved with mobile_allocate_remote_device, and reserving one may be a limited/billed resource. " +
+			"Requires mobile_login_to_cloud_provider to have been called first; if this fails with an authentication error, call that tool then retry.",
 			{},
 			{ readOnlyHint: true },
 			async ({}) => {
@@ -324,14 +406,23 @@ export const createMcpServer = (): McpServer => {
 		tool(
 			"mobile_allocate_remote_device",
 			"Allocate Remote Device",
-			"Reserve a device from the remote fleet",
+			"Reserve a physical device from the remote cloud fleet for exclusive use, returning a device identifier usable with the other mobile_* tools. " +
+			"Unlike local devices, a remote device is a shared and potentially billed resource borrowed for the session - only call this after the user has explicitly asked to use a remote/cloud device, never speculatively or as a fallback when a local device isn't found. " +
+			"Requires mobile_login_to_cloud_provider to have been called first; if this fails with an authentication error, call that tool then retry. " +
+			"Use mobile_list_remote_devices first to see which names and versions actually exist in the fleet before filtering by them. " +
+			"Release the device with mobile_release_remote_device once the whole task is finished - releasing wipes the device's state, so do not release and reallocate between steps of the same task just to be tidy.",
 			{
 				platform: z.enum(["ios", "android"]).describe("The platform to allocate a device for"),
+				name: z.array(z.string()).optional().describe("Filter by device name/model. Supports a trailing * for prefix match (e.g. \"iPhone*\"), or an exact name (e.g. \"iPhone 16\"). Multiple values are ANDed together."),
+				version: z.array(z.string()).optional().describe("Filter by OS version. Supports comparison prefixes >=, >, <=, < (e.g. \">=18\"), or an exact version (e.g. \"18.6.2\"). Multiple values are ANDed together."),
+				type: z.enum(["real"]).optional().describe("Device type filter. Currently only \"real\" (physical devices) is supported by the fleet."),
+				wait: z.boolean().optional().describe("If true, block until the device has finished allocating and is ready to use, up to timeoutSeconds. If false/omitted, this returns as soon as the reservation is made, but the device may not be immediately ready."),
+				timeoutSeconds: z.coerce.number().optional().describe("Seconds to wait for allocation when wait is true. Defaults to 900 (15 minutes). Only relevant when wait is true."),
 			},
 			{ destructiveHint: true },
-			async ({ platform }) => {
+			async ({ platform, name, version, type, wait, timeoutSeconds }) => {
 				ensureMobilecliAvailable();
-				const result = mobilecli.remoteAllocate(platform);
+				const result = mobilecli.remoteAllocate({ platform, name, version, type, wait, timeoutSeconds });
 				return result;
 			}
 		);
@@ -339,7 +430,9 @@ export const createMcpServer = (): McpServer => {
 		tool(
 			"mobile_release_remote_device",
 			"Release Remote Device",
-			"Release a device back to the remote fleet",
+			"Release a device previously reserved with mobile_allocate_remote_device back to the remote cloud fleet so it becomes available to others. " +
+			"Releasing is destructive to the device's state: apps installed, files pushed, and any other changes made during this session are lost, and a later mobile_allocate_remote_device call may take time and could return a different physical unit. " +
+			"Only release once the whole task is finished - if there is more work to do on the same device shortly, keep holding it rather than releasing and reallocating.",
 			{
 				device: z.string().describe("The device identifier to release back to the remote fleet"),
 			},

--- a/src/server.ts
+++ b/src/server.ts
@@ -339,6 +339,8 @@ export const createMcpServer = (): McpServer => {
 				const promptTimeout = setTimeout(() => {
 					if (!settled) {
 						settled = true;
+						forget();
+						child.kill();
 						reject(new ActionableError(`Timed out waiting for the login prompt from mobilecli. Output so far: ${output.trim() || "(none)"}`));
 					}
 				}, LOGIN_PROMPT_TIMEOUT_MS);
@@ -412,11 +414,11 @@ export const createMcpServer = (): McpServer => {
 		"Release the device with mobile_release_remote_device once the whole task is finished - releasing wipes the device's state, so do not release and reallocate between steps of the same task just to be tidy.",
 		{
 			platform: z.enum(["ios", "android"]).describe("The platform to allocate a device for"),
-			name: z.array(z.string()).optional().describe("Filter by device name/model. Supports a trailing * for prefix match (e.g. \"iPhone*\"), or an exact name (e.g. \"iPhone 16\"). Multiple values are ANDed together."),
+			name: z.string().optional().describe("Filter by device name/model. Supports a trailing * for prefix match (e.g. \"iPhone*\"), or an exact name (e.g. \"iPhone 16\")."),
 			version: z.array(z.string()).optional().describe("Filter by OS version. Supports comparison prefixes >=, >, <=, < (e.g. \">=18\"), or an exact version (e.g. \"18.6.2\"). Multiple values are ANDed together."),
 			type: z.enum(["real"]).optional().describe("Device type filter. Currently only \"real\" (physical devices) is supported by the fleet."),
 			wait: z.boolean().optional().describe("If true, block until the device has finished allocating and is ready to use, up to timeoutSeconds. If false/omitted, this returns as soon as the reservation is made, but the device may not be immediately ready."),
-			timeoutSeconds: z.coerce.number().optional().describe("Seconds to wait for allocation when wait is true. Defaults to 900 (15 minutes). Only relevant when wait is true."),
+			timeoutSeconds: z.coerce.number().int().positive().optional().describe("Seconds to wait for allocation when wait is true. Defaults to 900 (15 minutes). Only relevant when wait is true."),
 		},
 		{ destructiveHint: true },
 		async ({ platform, name, version, type, wait, timeoutSeconds }) => {


### PR DESCRIPTION
## Summary
- Add `mobile_login_to_cloud_provider`: spawns `mobilecli auth login` (device-code browser flow), parses the URL + one-time code from its stdout as soon as they're printed, and returns immediately instead of blocking on the user's browser approval. The login process keeps polling in the background; repeated calls are tracked in a list so earlier in-flight logins aren't dropped or killed.
- Expand `mobile_allocate_remote_device` to accept `mobilecli remote allocate`'s full filter set: `name` (wildcard/exact), `version` (comparison operators), `type`, `wait`, and `timeoutSeconds` — previously only `platform` was exposed.
- Rewrite the remote-device tool descriptions to spell out: the local-vs-remote distinction, that login must happen first, that allocation should only happen with explicit user intent (not speculatively), and that releasing a device wipes its state and may be slow to reallocate.
- `Mobilecli.executeCommand` now takes an optional timeout so `remoteAllocate({ wait: true })` doesn't get killed by Node before mobilecli's own (up to 900s) allocation timeout elapses.
- Remove the `MOBILEFLEET_ENABLE` opt-in flag: the four remote-device tools are now always registered. The actual safety net is in the tool descriptions themselves (explicit-consent language, login-required-first, don't idly release/reallocate), not a hidden env var, so gating visibility behind a flag no longer added anything.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint src/server.ts src/mobilecli.ts` passes
- [x] `npm run build` succeeds
- [x] `npx playwright test test/mobilecli.test.ts` (existing unit tests) passes
- [x] Manually exercised end-to-end against the live fleet: login → list remote devices → allocate (with `name` filter) → install/launch an app on the allocated device → release
- [ ] No new automated tests were added for the new `remoteAllocate` filters or `spawnRemoteLogin` parsing logic — happy to add if wanted