### PR TITLE
feat: support MCP protocol revision 2026-07-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,9 +392,14 @@ The single `/mcp` endpoint serves three eras at once:
 | MCP `2025-*` | Streamable HTTP | `POST /mcp` without an envelope, answered per request by the SDK's stateless legacy path. |
 | MCP `2024-11-05` | HTTP+SSE (deprecated) | `GET /mcp` opens the stream, which advertises `POST /mcp?sessionId=...` for messages. |
 
+Requests are separated by what they carry, so the two `GET` clients and the two `POST` clients never take each other's path:
+
+- A `GET /mcp` carrying `MCP-Protocol-Version` or `Mcp-Session-Id` is the optional listening stream a Streamable HTTP client opens after connecting; it is answered with `405`, which those clients treat as "no stream offered". Only a bare `GET /mcp` opens the HTTP+SSE stream.
+- A `POST /mcp` goes to the HTTP+SSE stream only when it carries the `sessionId` the open stream advertised. An unknown `sessionId` is refused with `404`; a `POST` with no `sessionId` goes to Streamable HTTP.
+
 Two known differences from earlier releases:
 
-- The HTTP+SSE stream still accepts one client at a time and answers a second concurrent `GET /mcp` with `409`, as before. A `POST /mcp` is routed to that stream only when it carries the `sessionId` query parameter the stream advertised — every other `POST` goes to Streamable HTTP. Clients using the SDK's own `SSEClientTransport` always send it.
+- The HTTP+SSE stream still accepts one client at a time and answers a second concurrent bare `GET /mcp` with `409`, as before. Clients using the SDK's own `SSEClientTransport` always send the advertised `sessionId` on their POSTs, so they are unaffected by the routing rule above.
 - Request bodies are capped at 4 MB, the same limit the MCP SDK v1 transports enforced. A larger body is refused with `413` before it is read.
 
 #### Authorization

--- a/README.md
+++ b/README.md
@@ -392,17 +392,21 @@ Two endpoints are served:
 | MCP `2025-*` | Streamable HTTP | `POST /mcp` without an envelope, answered per request by the SDK's stateless legacy path. |
 | MCP `2024-11-05` | HTTP+SSE (deprecated) | **`GET /sse`** opens the stream, which advertises `POST /mcp?sessionId=...` for messages. |
 
-The deprecated transport has its own path because a shared `GET` cannot be classified: once a client has completed `initialize` it reports a protocol version on every request, so a reconnecting `EventSource` is byte for byte the optional listening `GET` a Streamable HTTP client opens. Routing on the endpoint instead of on headers removes the guesswork:
+The deprecated transport has its own path because a shared `GET` cannot be classified by MCP headers alone: once a client has completed `initialize` it reports a protocol version on every request, so a re-establishing `EventSource` looks like the optional listening `GET` a Streamable HTTP client opens. `GET /mcp` is still classified, so clients configured against it before `/sse` existed keep working:
 
-- **`GET /sse`** always opens an HTTP+SSE stream. Streams are concurrent (up to 8), so no client can deny another one.
-- **`GET /mcp`** carrying `MCP-Protocol-Version` or `Mcp-Session-Id` is a Streamable HTTP listening stream and is answered `405`, which those clients treat as "no stream offered".
-- **`GET /mcp`** carrying a `Last-Event-ID` this server issued is a stream resumption and is served as one, wherever it arrives.
-- Any other **`GET /mcp`** is redirected (`301`) to `/sse`.
+- **`GET /sse`** always opens an HTTP+SSE stream — no classification, and the recommended endpoint for 2024-11-05 clients. Streams are concurrent (up to 8), so no client can deny another one.
+- **`GET /mcp`** is treated as HTTP+SSE when it carries a `Last-Event-ID` this server issued, or the cache signature every `EventSource` request has (`cache-control: no-cache`/`no-store` or `pragma: no-cache`). It is answered `301` to `/sse`, which the client follows on every attempt including reconnects.
+- **`GET /mcp`** carrying `MCP-Protocol-Version` or `Mcp-Session-Id` and none of those signals is a Streamable HTTP listening stream, and is answered `405` — which those clients treat as "no stream offered".
+- Any other **`GET /mcp`** is redirected to `/sse`.
 - **`POST /mcp?sessionId=...`** is delivered to the stream that advertised that id; an unknown id is refused with `404`. A `POST` with no `sessionId` goes to Streamable HTTP.
 
 Authorization and the cross-origin block apply to every one of these, including the redirect.
 
-> **Point 2024-11-05 clients at `/sse`.** A client still configured against `/mcp` connects through the redirect, but cannot re-establish its stream after a network drop: MCP SDK v1's `SSEClientTransport` hands `EventSource` a `fetch` that replaces the request headers wholesale, discarding the `Last-Event-ID` that would identify the reconnect, and the redirect is not retained across reconnects (per the EventSource specification only the connection URL of the *current* connection is updated). Its reconnect is then indistinguishable from a Streamable HTTP listening `GET` and is answered `405`. Clients configured against `/sse` reconnect there indefinitely.
+The cache signature is structural rather than incidental: the `eventsource` package issues its request with fetch cache mode `no-store`, and the Fetch standard requires such a request to be sent with `pragma: no-cache` and `cache-control: no-cache`. `StreamableHTTPClientTransport` issues its listening `GET` with the default cache mode and is sent neither. Either header on its own is accepted, so an intermediary that drops one does not cost a client its stream; a cache directive that is not `no-cache`/`no-store` (`max-age=600`, say) is not a match.
+
+> **Prefer `/sse` for 2024-11-05 clients.** It needs no classification at all, so it is the robust endpoint. `/mcp` is supported for existing configurations on the strength of the signature above, which holds for the shipped MCP SDK v1 client stack but is a heuristic: a future client that opens its listening stream with `no-cache`, or an intermediary that adds the header, would be handed a stream it does not want (it is ignored, and streams are concurrent, so nothing is locked out).
+
+Note that a re-established stream is a **new session**, not a resumption: the client receives a fresh `endpoint` event with a new `sessionId` and no missed events are replayed. `Last-Event-ID` is used only to recognise the client, never to resume a position.
 
 Other differences from earlier releases:
 

--- a/README.md
+++ b/README.md
@@ -384,22 +384,29 @@ Then configure your MCP client to connect to `http://<host>:3000/mcp`.
 
 #### Protocol compatibility
 
-The single `/mcp` endpoint serves three eras at once:
+Two endpoints are served:
 
-| Client | Wire | How it is routed |
+| Client | Wire | Endpoint |
 |---|---|---|
 | MCP `2026-07-28` | Streamable HTTP, stateless | `POST /mcp` with a `_meta` protocol envelope. No `initialize` handshake and no `Mcp-Session-Id`; the server is discovered with `server/discover`. |
 | MCP `2025-*` | Streamable HTTP | `POST /mcp` without an envelope, answered per request by the SDK's stateless legacy path. |
-| MCP `2024-11-05` | HTTP+SSE (deprecated) | `GET /mcp` opens the stream, which advertises `POST /mcp?sessionId=...` for messages. |
+| MCP `2024-11-05` | HTTP+SSE (deprecated) | **`GET /sse`** opens the stream, which advertises `POST /mcp?sessionId=...` for messages. |
 
-Requests are separated by what they carry, so the two `GET` clients and the two `POST` clients never take each other's path:
+The deprecated transport has its own path because a shared `GET` cannot be classified: once a client has completed `initialize` it reports a protocol version on every request, so a reconnecting `EventSource` is byte for byte the optional listening `GET` a Streamable HTTP client opens. Routing on the endpoint instead of on headers removes the guesswork:
 
-- A `GET /mcp` carrying `MCP-Protocol-Version` or `Mcp-Session-Id` is the optional listening stream a Streamable HTTP client opens after connecting; it is answered with `405`, which those clients treat as "no stream offered". Only a bare `GET /mcp` opens the HTTP+SSE stream.
-- A `POST /mcp` goes to the HTTP+SSE stream only when it carries the `sessionId` the open stream advertised. An unknown `sessionId` is refused with `404`; a `POST` with no `sessionId` goes to Streamable HTTP.
+- **`GET /sse`** always opens an HTTP+SSE stream. Streams are concurrent (up to 8), so no client can deny another one.
+- **`GET /mcp`** carrying `MCP-Protocol-Version` or `Mcp-Session-Id` is a Streamable HTTP listening stream and is answered `405`, which those clients treat as "no stream offered".
+- **`GET /mcp`** carrying a `Last-Event-ID` this server issued is a stream resumption and is served as one, wherever it arrives.
+- Any other **`GET /mcp`** is redirected (`301`) to `/sse`.
+- **`POST /mcp?sessionId=...`** is delivered to the stream that advertised that id; an unknown id is refused with `404`. A `POST` with no `sessionId` goes to Streamable HTTP.
 
-Two known differences from earlier releases:
+Authorization and the cross-origin block apply to every one of these, including the redirect.
 
-- The HTTP+SSE stream still accepts one client at a time and answers a second concurrent bare `GET /mcp` with `409`, as before. Clients using the SDK's own `SSEClientTransport` always send the advertised `sessionId` on their POSTs, so they are unaffected by the routing rule above.
+> **Point 2024-11-05 clients at `/sse`.** A client still configured against `/mcp` connects through the redirect, but cannot re-establish its stream after a network drop: MCP SDK v1's `SSEClientTransport` hands `EventSource` a `fetch` that replaces the request headers wholesale, discarding the `Last-Event-ID` that would identify the reconnect, and the redirect is not retained across reconnects (per the EventSource specification only the connection URL of the *current* connection is updated). Its reconnect is then indistinguishable from a Streamable HTTP listening `GET` and is answered `405`. Clients configured against `/sse` reconnect there indefinitely.
+
+Other differences from earlier releases:
+
+- The HTTP+SSE stream used to be single-client and answered a second connection with `409`; it now serves up to 8 concurrent streams and answers `429` beyond that.
 - Request bodies are capped at 4 MB, the same limit the MCP SDK v1 transports enforced. A larger body is refused with `413` before it is read.
 
 #### Authorization

--- a/README.md
+++ b/README.md
@@ -382,7 +382,20 @@ npx @mobilenext/mobile-mcp@latest --listen 0.0.0.0:3000
 
 Then configure your MCP client to connect to `http://<host>:3000/mcp`.
 
-Both transports speak MCP protocol revision `2026-07-28` and the 2025-era revisions. Modern clients send stateless, self-contained requests — no `initialize` handshake and no `Mcp-Session-Id` — and discover the server with `server/discover`; 2025-era clients keep working unchanged on the same endpoint.
+#### Protocol compatibility
+
+The single `/mcp` endpoint serves three eras at once:
+
+| Client | Wire | How it is routed |
+|---|---|---|
+| MCP `2026-07-28` | Streamable HTTP, stateless | `POST /mcp` with a `_meta` protocol envelope. No `initialize` handshake and no `Mcp-Session-Id`; the server is discovered with `server/discover`. |
+| MCP `2025-*` | Streamable HTTP | `POST /mcp` without an envelope, answered per request by the SDK's stateless legacy path. |
+| MCP `2024-11-05` | HTTP+SSE (deprecated) | `GET /mcp` opens the stream, which advertises `POST /mcp?sessionId=...` for messages. |
+
+Two known differences from earlier releases:
+
+- The HTTP+SSE stream still accepts one client at a time and answers a second concurrent `GET /mcp` with `409`, as before. A `POST /mcp` is routed to that stream only when it carries the `sessionId` query parameter the stream advertised — every other `POST` goes to Streamable HTTP. Clients using the SDK's own `SSEClientTransport` always send it.
+- Request bodies are capped at 4 MB, the same limit the MCP SDK v1 transports enforced. A larger body is refused with `413` before it is read.
 
 #### Authorization
 

--- a/README.md
+++ b/README.md
@@ -366,9 +366,9 @@ Once the server is configured, ask your agent to list devices:
 
 You should get back your running simulators, emulators, and connected devices. If you do, Mobile MCP is wired up correctly. If the list is empty, make sure a simulator or emulator is running (see [Prerequisites](#prerequisites)) — for more help, check the [wiki](https://github.com/mobile-next/mobile-mcp/wiki).
 
-### SSE Server Mode
+### HTTP Server Mode
 
-By default, Mobile MCP runs over stdio. To start an SSE server instead, use the `--listen` flag:
+By default, Mobile MCP runs over stdio. To start an HTTP server instead, use the `--listen` flag:
 
 ```bash
 npx @mobilenext/mobile-mcp@latest --listen 3000
@@ -382,9 +382,11 @@ npx @mobilenext/mobile-mcp@latest --listen 0.0.0.0:3000
 
 Then configure your MCP client to connect to `http://<host>:3000/mcp`.
 
+Both transports speak MCP protocol revision `2026-07-28` and the 2025-era revisions. Modern clients send stateless, self-contained requests — no `initialize` handshake and no `Mcp-Session-Id` — and discover the server with `server/discover`; 2025-era clients keep working unchanged on the same endpoint.
+
 #### Authorization
 
-To require Bearer token authorization on the SSE server, set the `MOBILEMCP_AUTH` environment variable:
+To require Bearer token authorization on the HTTP server, set the `MOBILEMCP_AUTH` environment variable:
 
 ```bash
 MOBILEMCP_AUTH=my-secret-token npx @mobilenext/mobile-mcp@latest --listen 3000
@@ -464,7 +466,7 @@ Gmail to contacts "team@example.com".
 
 | Variable | Description | Example |
 |---|---|---|
-| `MOBILEMCP_AUTH` | Require a Bearer token on the SSE server — every request must then send `Authorization: Bearer <token>`. | `MOBILEMCP_AUTH=my-secret-token` |
+| `MOBILEMCP_AUTH` | Require a Bearer token on the HTTP server — every request must then send `Authorization: Bearer <token>`. | `MOBILEMCP_AUTH=my-secret-token` |
 | `MOBILEMCP_DISABLE_TELEMETRY` | Disable anonymous usage telemetry. | `MOBILEMCP_DISABLE_TELEMETRY=1` |
 | `MOBILEMCP_ALLOW_UNSAFE_URLS` | Allow `mobile_open_url` to open non-standard URL schemes (blocked by default). | `MOBILEMCP_ALLOW_UNSAFE_URLS=1` |
 | `MOBILEMCP_LEGACY_ROBOT` | Use the legacy platform-specific robots for Android devices and physical iOS devices. iOS simulators continue to use `mobilecli`. | `MOBILEMCP_LEGACY_ROBOT=1` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/node": "2.0.0",
+        "@modelcontextprotocol/sdk": "1.26.0",
         "@modelcontextprotocol/server": "2.0.0",
         "ajv": "^8.18.0",
         "commander": "14.0.0",
@@ -995,6 +996,98 @@
         }
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "node_modules/@modelcontextprotocol/server": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
@@ -1597,6 +1690,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -2207,11 +2317,27 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2945,6 +3071,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
@@ -2985,6 +3132,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3565,7 +3731,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
       "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3687,8 +3852,7 @@
         "node": ">= 0.4"
       }
     },
-<<<<<<< HEAD
-    "node_modules/ip-address": {
+      "node_modules/ip-address": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
       "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
@@ -3697,9 +3861,7 @@
         "node": ">= 12"
       }
     },
-=======
->>>>>>> 8a8500a (feat: implement mcp protocol revision 2026-07-28 on sdk v2)
-    "node_modules/ipaddr.js": {
+      "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
@@ -4174,7 +4336,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4248,6 +4409,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
@@ -4283,6 +4453,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4535,6 +4711,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -4798,7 +4983,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4856,6 +5040,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -5396,7 +5589,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5409,7 +5601,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6031,7 +6222,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.26.0",
+        "@modelcontextprotocol/node": "2.0.0",
+        "@modelcontextprotocol/server": "2.0.0",
         "ajv": "^8.18.0",
         "commander": "14.0.0",
         "express": "5.1.0",
@@ -961,96 +962,50 @@
         "node": ">=18"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
       },
       "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
+        "hono": {
           "optional": true
-        },
-        "zod": {
-          "optional": false
         }
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
       },
       "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "node": ">=20"
       }
     },
     "node_modules/@nodable/entities": {
@@ -1642,23 +1597,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/ansi-regex": {
@@ -2269,23 +2207,11 @@
         "node": ">=6.6.0"
       }
     },
-    "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3019,27 +2945,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/express": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
@@ -3080,24 +2985,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.2.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3678,6 +3565,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
       "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3799,6 +3687,7 @@
         "node": ">= 0.4"
       }
     },
+<<<<<<< HEAD
     "node_modules/ip-address": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
@@ -3808,6 +3697,8 @@
         "node": ">= 12"
       }
     },
+=======
+>>>>>>> 8a8500a (feat: implement mcp protocol revision 2026-07-28 on sdk v2)
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -4283,6 +4174,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4356,15 +4248,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/js-yaml": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
@@ -4400,12 +4283,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4658,15 +4535,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -4930,6 +4798,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4987,15 +4856,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -5536,6 +5396,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5548,6 +5409,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6169,6 +6031,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6529,9 +6392,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
-      "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lib"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.26.0",
+    "@modelcontextprotocol/node": "2.0.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "ajv": "^8.18.0",
     "commander": "14.0.0",
     "express": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/node": "2.0.0",
+    "@modelcontextprotocol/sdk": "1.26.0",
     "@modelcontextprotocol/server": "2.0.0",
     "ajv": "^8.18.0",
     "commander": "14.0.0",

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -8,6 +8,7 @@ import { createLegacySseEndpoint } from "./legacy-sse";
 import { error } from "./logger";
 
 export const MCP_ENDPOINT = "/mcp";
+export const SSE_ENDPOINT = "/sse";
 
 /**
  * The cap MCP SDK v1 enforced on posted message bodies. The v2 node adapter
@@ -22,6 +23,13 @@ const payloadTooLarge = () => ({
 	error: { code: -32000, message: `Payload Too Large: request body exceeds ${MAXIMUM_MESSAGE_SIZE}` },
 	id: null,
 });
+
+/**
+ * Headers a Streamable HTTP client attaches to the optional listening GET it
+ * opens once connected. They are only consulted after the HTTP+SSE resumption
+ * marker has been ruled out.
+ */
+const STREAMABLE_HTTP_GET_HEADERS = ["mcp-session-id", "mcp-protocol-version"];
 
 export interface HttpApp {
 	app: express.Express;
@@ -95,22 +103,34 @@ export const createHttpApp = (): HttpApp => {
 		onerror: err => error(`mcp http handler error: ${err.message}`),
 	});
 
-	// The deprecated HTTP+SSE transport (2024-11-05) is still served on the same
-	// endpoint by the v1 transport, so clients that open a stream with GET keep
-	// working. See src/legacy-sse.ts.
+	// The deprecated HTTP+SSE transport (2024-11-05) owns its own path, so a
+	// reconnecting EventSource never has to be told apart from a Streamable HTTP
+	// listening GET on shared ground. See src/legacy-sse.ts.
 	const legacySse = createLegacySseEndpoint(MCP_ENDPOINT);
 
+	app.get(SSE_ENDPOINT, (req, res) => {
+		legacySse.openStream(req, res);
+	});
+
 	app.get(MCP_ENDPOINT, (req, res) => {
+		// A spec-compliant EventSource resuming one of our streams says so with
+		// Last-Event-ID, and is served wherever it asks.
+		if (legacySse.isStreamResumption(req)) {
+			legacySse.openStream(req, res);
+			return;
+		}
+
 		// A Streamable HTTP client opens an optional listening stream with GET
-		// after connecting. Routing it here would burn the single legacy slot and
-		// lock out genuine 2024-11-05 clients, so it goes to the modern handler
-		// and gets the 405 it expects.
-		if (!legacySse.isStreamRequest(req)) {
+		// after connecting. It must reach the modern handler and get the 405 it
+		// expects, never an HTTP+SSE stream.
+		if (STREAMABLE_HTTP_GET_HEADERS.some(header => req.headers[header] !== undefined)) {
 			streamableHttp(req, res, req.body);
 			return;
 		}
 
-		legacySse.openStream(req, res);
+		// Anything else on this GET is an HTTP+SSE client opening a stream — it
+		// has nothing to report yet. Send it to the path that owns the transport.
+		res.redirect(301, SSE_ENDPOINT);
 	});
 
 	app.post(MCP_ENDPOINT, (req, res) => {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -25,10 +25,18 @@ export const SHUTDOWN_TIMEOUT_MS = 5_000;
 const digest = (value: string): Buffer => createHash("sha256").update(value).digest();
 
 /** The shape body-parser gives its failures. */
-interface HttpError extends Error {
-	type?: string;
-	status?: number;
+interface BodyParserError extends Error {
+	type: string;
 }
+
+/** Narrows a thrown value to a body-parser failure, which names itself in `type`. */
+const isBodyParserError = (err: unknown): err is BodyParserError => {
+	return err instanceof Error && "type" in err && typeof err.type === "string";
+};
+
+const describeError = (err: unknown): string => {
+	return err instanceof Error ? err.message : String(err);
+};
 
 const payloadTooLarge = () => ({
 	jsonrpc: "2.0",
@@ -145,20 +153,19 @@ export const createHttpApp = (): HttpApp => {
 
 	// Mounted for the whole app, not just one endpoint, so a rejection from any
 	// route reaches it. Express 5 forwards a returned rejected promise here.
-	app.use((err: express.Errback | HttpError, req: express.Request, res: express.Response, next: express.NextFunction) => {
+	app.use((err: unknown, req: express.Request, res: express.Response, next: express.NextFunction) => {
 		if (res.headersSent) {
 			next(err);
 			return;
 		}
 
-		const type = (err as HttpError)?.type;
-		if (type === "entity.too.large") {
-			res.status(413).json(payloadTooLarge());
-			return;
-		}
+		if (isBodyParserError(err)) {
+			if (err.type === "entity.too.large") {
+				res.status(413).json(payloadTooLarge());
+				return;
+			}
 
-		// every other body-parser failure is a malformed request body
-		if (typeof type === "string") {
+			// every other body-parser failure is a malformed request body
 			res.status(400).json({
 				jsonrpc: "2.0",
 				error: { code: -32700, message: "Parse error" },
@@ -167,7 +174,7 @@ export const createHttpApp = (): HttpApp => {
 			return;
 		}
 
-		error(`mcp http request failed: ${(err as Error)?.message}`);
+		error(`mcp http request failed: ${describeError(err)}`);
 		res.status(500).json({
 			jsonrpc: "2.0",
 			error: { code: -32603, message: "Internal error" },
@@ -224,8 +231,8 @@ export const createShutdownHandler = (server: Server, close: () => Promise<void>
 		}
 
 		started = true;
-		closeHttpServer(server, close).then(onSettled, err => {
-			error(`mcp http shutdown failed: ${(err as Error)?.message}`);
+		closeHttpServer(server, close).then(onSettled, (err: unknown) => {
+			error(`mcp http shutdown failed: ${describeError(err)}`);
 			onSettled();
 		});
 	};

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,6 +1,7 @@
 import { createMcpHandler } from "@modelcontextprotocol/server";
 import { toNodeHandler } from "@modelcontextprotocol/node";
 import express from "express";
+import type { Server } from "node:http";
 
 import { createMcpServer } from "./server";
 import { createLegacySseEndpoint } from "./legacy-sse";
@@ -100,11 +101,20 @@ export const createHttpApp = (): HttpApp => {
 	const legacySse = createLegacySseEndpoint(MCP_ENDPOINT);
 
 	app.get(MCP_ENDPOINT, (req, res) => {
+		// A Streamable HTTP client opens an optional listening stream with GET
+		// after connecting. Routing it here would burn the single legacy slot and
+		// lock out genuine 2024-11-05 clients, so it goes to the modern handler
+		// and gets the 405 it expects.
+		if (!legacySse.isStreamRequest(req)) {
+			streamableHttp(req, res, req.body);
+			return;
+		}
+
 		legacySse.openStream(req, res);
 	});
 
 	app.post(MCP_ENDPOINT, (req, res) => {
-		if (legacySse.isSseMessage(req)) {
+		if (legacySse.isMessageRequest(req)) {
 			legacySse.handleMessage(req, res);
 			return;
 		}
@@ -140,4 +150,15 @@ export const createHttpApp = (): HttpApp => {
 	};
 
 	return { app, close };
+};
+
+/**
+ * Shuts an mcp http server down: the mcp resources first — the modern handler's
+ * in-flight exchanges and the open sse stream, which would otherwise hold the
+ * listener open indefinitely — then the listener itself.
+ */
+export const closeHttpServer = async (server: Server, close: () => Promise<void>): Promise<void> => {
+	await close();
+	server.closeAllConnections();
+	await new Promise<void>(resolve => server.close(() => resolve()));
 };

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,0 +1,143 @@
+import { createMcpHandler } from "@modelcontextprotocol/server";
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import express from "express";
+
+import { createMcpServer } from "./server";
+import { createLegacySseEndpoint } from "./legacy-sse";
+import { error } from "./logger";
+
+export const MCP_ENDPOINT = "/mcp";
+
+/**
+ * The cap MCP SDK v1 enforced on posted message bodies. The v2 node adapter
+ * buffers whatever the request stream yields, so the limit has to be applied
+ * here, before the body reaches it.
+ */
+export const MAXIMUM_MESSAGE_SIZE = "4mb";
+export const MAXIMUM_MESSAGE_SIZE_BYTES = 4 * 1024 * 1024;
+
+const payloadTooLarge = () => ({
+	jsonrpc: "2.0",
+	error: { code: -32000, message: `Payload Too Large: request body exceeds ${MAXIMUM_MESSAGE_SIZE}` },
+	id: null,
+});
+
+export interface HttpApp {
+	app: express.Express;
+	close: () => Promise<void>;
+}
+
+export const createHttpApp = (): HttpApp => {
+	const app = express();
+
+	const authToken = process.env.MOBILEMCP_AUTH;
+	if (!authToken) {
+		error("WARNING: MOBILEMCP_AUTH is not set. The http server will accept unauthenticated connections. Set MOBILEMCP_AUTH to require Bearer token authentication.");
+	}
+
+	if (authToken) {
+		app.use((req, res, next) => {
+			if (req.headers.authorization !== `Bearer ${authToken}`) {
+				res.status(401).json({ error: "Unauthorized" });
+				return;
+			}
+
+			next();
+		});
+	}
+
+	// Block cross-origin requests — MCP clients are not browsers
+	app.use((req, res, next) => {
+		if (req.headers.origin) {
+			res.status(403).json({ error: "Cross-origin requests are not allowed" });
+			return;
+		}
+
+		if (req.method === "OPTIONS") {
+			res.status(403).end();
+			return;
+		}
+
+		next();
+	});
+
+	// Reject an oversized body from its declared length, before a single byte is
+	// read. body-parser also enforces the limit, but only after draining the
+	// request, so this keeps the fail-fast behavior MCP SDK v1 had.
+	app.use(MCP_ENDPOINT, (req, res, next) => {
+		const declaredLength = Number(req.headers["content-length"]);
+		if (Number.isFinite(declaredLength) && declaredLength > MAXIMUM_MESSAGE_SIZE_BYTES) {
+			res.status(413).json(payloadTooLarge());
+			return;
+		}
+
+		next();
+	});
+
+	// Bound every posted body before the v2 node adapter (or the v1 sse
+	// transport) sees it: both would otherwise buffer an arbitrarily large
+	// request into memory. Parsing every content type keeps the body out of the
+	// adapter's own unbounded reader; the servers still apply their own
+	// content-type rules to what they receive.
+	app.use(MCP_ENDPOINT, express.json({ limit: MAXIMUM_MESSAGE_SIZE, type: () => true }));
+
+	// Modern (2026-07-28) requests are stateless and self-contained, so a fresh
+	// server instance serves every request. `legacy: "stateless"` keeps 2025-era
+	// Streamable HTTP clients working on the same endpoint, with no session
+	// singleton.
+	const handler = createMcpHandler(createMcpServer, {
+		legacy: "stateless",
+		onerror: err => error(`mcp http error: ${err.message}`),
+	});
+
+	const streamableHttp = toNodeHandler(handler, {
+		onerror: err => error(`mcp http handler error: ${err.message}`),
+	});
+
+	// The deprecated HTTP+SSE transport (2024-11-05) is still served on the same
+	// endpoint by the v1 transport, so clients that open a stream with GET keep
+	// working. See src/legacy-sse.ts.
+	const legacySse = createLegacySseEndpoint(MCP_ENDPOINT);
+
+	app.get(MCP_ENDPOINT, (req, res) => {
+		legacySse.openStream(req, res);
+	});
+
+	app.post(MCP_ENDPOINT, (req, res) => {
+		if (legacySse.isSseMessage(req)) {
+			legacySse.handleMessage(req, res);
+			return;
+		}
+
+		streamableHttp(req, res, req.body);
+	});
+
+	app.all(MCP_ENDPOINT, (req, res) => {
+		streamableHttp(req, res, req.body);
+	});
+
+	app.use(MCP_ENDPOINT, (err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+		if (res.headersSent) {
+			next(err);
+			return;
+		}
+
+		if (err?.type === "entity.too.large") {
+			res.status(413).json(payloadTooLarge());
+			return;
+		}
+
+		res.status(400).json({
+			jsonrpc: "2.0",
+			error: { code: -32700, message: "Parse error" },
+			id: null,
+		});
+	});
+
+	const close = async () => {
+		await legacySse.close();
+		await handler.close();
+	};
+
+	return { app, close };
+};

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -2,6 +2,7 @@ import { createMcpHandler } from "@modelcontextprotocol/server";
 import { toNodeHandler } from "@modelcontextprotocol/node";
 import express from "express";
 import type { Server } from "node:http";
+import { createHash, timingSafeEqual } from "node:crypto";
 
 import { createMcpServer } from "./server";
 import { createLegacySseEndpoint } from "./legacy-sse";
@@ -17,6 +18,17 @@ export const SSE_ENDPOINT = "/sse";
  */
 export const MAXIMUM_MESSAGE_SIZE = "4mb";
 export const MAXIMUM_MESSAGE_SIZE_BYTES = 4 * 1024 * 1024;
+
+/** Time the shutdown sequence is given before the process stops waiting for it. */
+export const SHUTDOWN_TIMEOUT_MS = 5_000;
+
+const digest = (value: string): Buffer => createHash("sha256").update(value).digest();
+
+/** The shape body-parser gives its failures. */
+interface HttpError extends Error {
+	type?: string;
+	status?: number;
+}
 
 const payloadTooLarge = () => ({
 	jsonrpc: "2.0",
@@ -38,8 +50,11 @@ export const createHttpApp = (): HttpApp => {
 	}
 
 	if (authToken) {
+		const expected = digest(`Bearer ${authToken}`);
 		app.use((req, res, next) => {
-			if (req.headers.authorization !== `Bearer ${authToken}`) {
+			// Compared as fixed-length digests so the check takes the same time
+			// whatever the supplied credential is, and leaks no length either.
+			if (!timingSafeEqual(digest(req.headers.authorization ?? ""), expected)) {
 				res.status(401).json({ error: "Unauthorized" });
 				return;
 			}
@@ -101,17 +116,14 @@ export const createHttpApp = (): HttpApp => {
 	// listening GET on shared ground. See src/legacy-sse.ts.
 	const legacySse = createLegacySseEndpoint(MCP_ENDPOINT);
 
-	app.get(SSE_ENDPOINT, (req, res) => {
-		legacySse.openStream(req, res);
-	});
+	app.get(SSE_ENDPOINT, (req, res) => legacySse.openStream(req, res));
 
 	app.get(MCP_ENDPOINT, (req, res) => {
 		// A Streamable HTTP client opens an optional listening stream with GET
 		// after connecting. It must reach the modern handler and get the 405 it
 		// expects, never an HTTP+SSE stream.
 		if (!legacySse.isStreamRequest(req)) {
-			streamableHttp(req, res, req.body);
-			return;
+			return streamableHttp(req, res, req.body);
 		}
 
 		// Everything else on this GET belongs to the HTTP+SSE transport — a client
@@ -123,31 +135,42 @@ export const createHttpApp = (): HttpApp => {
 
 	app.post(MCP_ENDPOINT, (req, res) => {
 		if (legacySse.isMessageRequest(req)) {
-			legacySse.handleMessage(req, res);
-			return;
+			return legacySse.handleMessage(req, res);
 		}
 
-		streamableHttp(req, res, req.body);
+		return streamableHttp(req, res, req.body);
 	});
 
-	app.all(MCP_ENDPOINT, (req, res) => {
-		streamableHttp(req, res, req.body);
-	});
+	app.all(MCP_ENDPOINT, (req, res) => streamableHttp(req, res, req.body));
 
-	app.use(MCP_ENDPOINT, (err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+	// Mounted for the whole app, not just one endpoint, so a rejection from any
+	// route reaches it. Express 5 forwards a returned rejected promise here.
+	app.use((err: express.Errback | HttpError, req: express.Request, res: express.Response, next: express.NextFunction) => {
 		if (res.headersSent) {
 			next(err);
 			return;
 		}
 
-		if (err?.type === "entity.too.large") {
+		const type = (err as HttpError)?.type;
+		if (type === "entity.too.large") {
 			res.status(413).json(payloadTooLarge());
 			return;
 		}
 
-		res.status(400).json({
+		// every other body-parser failure is a malformed request body
+		if (typeof type === "string") {
+			res.status(400).json({
+				jsonrpc: "2.0",
+				error: { code: -32700, message: "Parse error" },
+				id: null,
+			});
+			return;
+		}
+
+		error(`mcp http request failed: ${(err as Error)?.message}`);
+		res.status(500).json({
 			jsonrpc: "2.0",
-			error: { code: -32700, message: "Parse error" },
+			error: { code: -32603, message: "Internal error" },
 			id: null,
 		});
 	});
@@ -162,11 +185,58 @@ export const createHttpApp = (): HttpApp => {
 
 /**
  * Shuts an mcp http server down: the mcp resources first — the modern handler's
- * in-flight exchanges and the open sse stream, which would otherwise hold the
+ * in-flight exchanges and the open sse streams, which would otherwise hold the
  * listener open indefinitely — then the listener itself.
+ *
+ * Bounded, so a resource that refuses to settle cannot hold a terminating
+ * process open forever.
  */
-export const closeHttpServer = async (server: Server, close: () => Promise<void>): Promise<void> => {
-	await close();
-	server.closeAllConnections();
-	await new Promise<void>(resolve => server.close(() => resolve()));
+export const closeHttpServer = async (server: Server, close: () => Promise<void>, timeoutMs: number = SHUTDOWN_TIMEOUT_MS): Promise<void> => {
+	let timer: NodeJS.Timeout | undefined;
+	const bound = new Promise<void>(resolve => {
+		timer = setTimeout(resolve, timeoutMs);
+		timer.unref();
+	});
+
+	const sequence = async () => {
+		await close();
+		server.closeAllConnections();
+		await new Promise<void>(resolve => server.close(() => resolve()));
+	};
+
+	try {
+		await Promise.race([sequence(), bound]);
+	} finally {
+		clearTimeout(timer);
+	}
+};
+
+/**
+ * A shutdown callback that runs the sequence once, however many signals arrive,
+ * and reports when it is done (or when it gave up waiting).
+ */
+export const createShutdownHandler = (server: Server, close: () => Promise<void>, onSettled: () => void): (() => void) => {
+	let started = false;
+
+	return () => {
+		if (started) {
+			return;
+		}
+
+		started = true;
+		closeHttpServer(server, close).then(onSettled, err => {
+			error(`mcp http shutdown failed: ${(err as Error)?.message}`);
+			onSettled();
+		});
+	};
+};
+
+/**
+ * Binds the listener, reporting a bind failure (a port already in use, an
+ * address that cannot be bound) instead of leaving it as an unhandled error.
+ */
+export const listenHttpServer = (app: express.Express, host: string, port: number, onListening: () => void, onError: (err: NodeJS.ErrnoException) => void): Server => {
+	const server = app.listen(port, host, onListening);
+	server.on("error", onError);
+	return server;
 };

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -24,13 +24,6 @@ const payloadTooLarge = () => ({
 	id: null,
 });
 
-/**
- * Headers a Streamable HTTP client attaches to the optional listening GET it
- * opens once connected. They are only consulted after the HTTP+SSE resumption
- * marker has been ruled out.
- */
-const STREAMABLE_HTTP_GET_HEADERS = ["mcp-session-id", "mcp-protocol-version"];
-
 export interface HttpApp {
 	app: express.Express;
 	close: () => Promise<void>;
@@ -113,23 +106,18 @@ export const createHttpApp = (): HttpApp => {
 	});
 
 	app.get(MCP_ENDPOINT, (req, res) => {
-		// A spec-compliant EventSource resuming one of our streams says so with
-		// Last-Event-ID, and is served wherever it asks.
-		if (legacySse.isStreamResumption(req)) {
-			legacySse.openStream(req, res);
-			return;
-		}
-
 		// A Streamable HTTP client opens an optional listening stream with GET
 		// after connecting. It must reach the modern handler and get the 405 it
 		// expects, never an HTTP+SSE stream.
-		if (STREAMABLE_HTTP_GET_HEADERS.some(header => req.headers[header] !== undefined)) {
+		if (!legacySse.isStreamRequest(req)) {
 			streamableHttp(req, res, req.body);
 			return;
 		}
 
-		// Anything else on this GET is an HTTP+SSE client opening a stream — it
-		// has nothing to report yet. Send it to the path that owns the transport.
+		// Everything else on this GET belongs to the HTTP+SSE transport — a client
+		// opening a stream, or re-establishing one — and is sent to the path that
+		// owns it. The redirect is followed on every attempt, so a client still
+		// configured against /mcp keeps working.
 		res.redirect(301, SSE_ENDPOINT);
 	});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,25 @@
 #!/usr/bin/env node
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { createMcpServer, getAgentVersion } from "./server";
-import { createHttpApp, MCP_ENDPOINT } from "./http-server";
+import { createHttpApp, closeHttpServer, MCP_ENDPOINT } from "./http-server";
 import { error } from "./logger";
 import { program } from "commander";
 
 const startHttpServer = async (host: string, port: number) => {
-	const { app } = createHttpApp();
+	const { app, close } = createHttpApp();
 
-	app.listen(port, host, () => {
+	const server = app.listen(port, host, () => {
 		error(`mobile-mcp ${getAgentVersion()} http server listening on http://${host}:${port}${MCP_ENDPOINT}`);
 	});
+
+	// Release the mcp resources — in-flight modern exchanges and the open sse
+	// stream — before the process goes away, as the stdio entry does.
+	const shutdown = () => {
+		closeHttpServer(server, close).finally(() => process.exit(0));
+	};
+
+	process.on("SIGINT", shutdown);
+	process.on("SIGTERM", shutdown);
 };
 
 const startStdioServer = async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,18 @@
 #!/usr/bin/env node
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createMcpHandler } from "@modelcontextprotocol/server";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
+import { toNodeHandler } from "@modelcontextprotocol/node";
 import { createMcpServer, getAgentVersion } from "./server";
 import { error } from "./logger";
 import express from "express";
 import { program } from "commander";
 
-const startSseServer = async (host: string, port: number) => {
+const startHttpServer = async (host: string, port: number) => {
 	const app = express();
-	const server = createMcpServer();
 
 	const authToken = process.env.MOBILEMCP_AUTH;
 	if (!authToken) {
-		error("WARNING: MOBILEMCP_AUTH is not set. The SSE server will accept unauthenticated connections. Set MOBILEMCP_AUTH to require Bearer token authentication.");
+		error("WARNING: MOBILEMCP_AUTH is not set. The http server will accept unauthenticated connections. Set MOBILEMCP_AUTH to require Bearer token authentication.");
 	}
 
 	if (authToken) {
@@ -41,40 +41,31 @@ const startSseServer = async (host: string, port: number) => {
 		next();
 	});
 
-	let transport: SSEServerTransport | null = null;
-
-	app.post("/mcp", (req, res) => {
-		if (transport) {
-			transport.handlePostMessage(req, res);
-		}
+	// Modern (2026-07-28) requests are stateless and self-contained, so a fresh
+	// server instance serves every request. `legacy: "stateless"` keeps 2025-era
+	// clients working on the same endpoint, with no session singleton.
+	const handler = createMcpHandler(createMcpServer, {
+		legacy: "stateless",
+		onerror: err => error(`mcp http error: ${err.message}`),
 	});
 
-	app.get("/mcp", (req, res) => {
-		if (transport) {
-			res.status(409).json({ error: "Another client is already connected. Disconnect the existing client first." });
-			return;
-		}
-
-		transport = new SSEServerTransport("/mcp", res);
-
-		transport.onclose = () => {
-			transport = null;
-		};
-
-		server.connect(transport);
-	});
+	app.all("/mcp", toNodeHandler(handler, {
+		onerror: err => error(`mcp http handler error: ${err.message}`),
+	}));
 
 	app.listen(port, host, () => {
-		error(`mobile-mcp ${getAgentVersion()} sse server listening on http://${host}:${port}/mcp`);
+		error(`mobile-mcp ${getAgentVersion()} http server listening on http://${host}:${port}/mcp`);
 	});
 };
 
 const startStdioServer = async () => {
 	try {
-		const transport = new StdioServerTransport();
-
-		const server = createMcpServer();
-		await server.connect(transport);
+		// serveStdio owns the era decision for the connection: a modern opening is
+		// served without an initialize handshake, while a 2025-era initialize pins
+		// a legacy instance from the same factory.
+		serveStdio(createMcpServer, {
+			onerror: err => error(`mcp stdio error: ${err.message}`),
+		});
 
 		// Exit cleanly on termination signals so node flushes pending work
 		// (including NODE_V8_COVERAGE output). Node's default SIGINT/SIGTERM
@@ -98,7 +89,7 @@ const startStdioServer = async () => {
 const main = async () => {
 	program
 		.version(getAgentVersion())
-		.option("--listen <listen>", "Start SSE server on [host:]port")
+		.option("--listen <listen>", "Start http server on [host:]port")
 		.option("--stdio", "Start stdio server (default)")
 		.parse(process.argv);
 
@@ -123,7 +114,7 @@ const main = async () => {
 			process.exit(1);
 		}
 
-		await startSseServer(host, port);
+		await startHttpServer(host, port);
 	} else {
 		await startStdioServer();
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,60 +1,15 @@
 #!/usr/bin/env node
-import { createMcpHandler } from "@modelcontextprotocol/server";
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
-import { toNodeHandler } from "@modelcontextprotocol/node";
 import { createMcpServer, getAgentVersion } from "./server";
+import { createHttpApp, MCP_ENDPOINT } from "./http-server";
 import { error } from "./logger";
-import express from "express";
 import { program } from "commander";
 
 const startHttpServer = async (host: string, port: number) => {
-	const app = express();
-
-	const authToken = process.env.MOBILEMCP_AUTH;
-	if (!authToken) {
-		error("WARNING: MOBILEMCP_AUTH is not set. The http server will accept unauthenticated connections. Set MOBILEMCP_AUTH to require Bearer token authentication.");
-	}
-
-	if (authToken) {
-		app.use((req, res, next) => {
-			if (req.headers.authorization !== `Bearer ${authToken}`) {
-				res.status(401).json({ error: "Unauthorized" });
-				return;
-			}
-
-			next();
-		});
-	}
-
-	// Block cross-origin requests — MCP clients are not browsers
-	app.use((req, res, next) => {
-		if (req.headers.origin) {
-			res.status(403).json({ error: "Cross-origin requests are not allowed" });
-			return;
-		}
-
-		if (req.method === "OPTIONS") {
-			res.status(403).end();
-			return;
-		}
-
-		next();
-	});
-
-	// Modern (2026-07-28) requests are stateless and self-contained, so a fresh
-	// server instance serves every request. `legacy: "stateless"` keeps 2025-era
-	// clients working on the same endpoint, with no session singleton.
-	const handler = createMcpHandler(createMcpServer, {
-		legacy: "stateless",
-		onerror: err => error(`mcp http error: ${err.message}`),
-	});
-
-	app.all("/mcp", toNodeHandler(handler, {
-		onerror: err => error(`mcp http handler error: ${err.message}`),
-	}));
+	const { app } = createHttpApp();
 
 	app.listen(port, host, () => {
-		error(`mobile-mcp ${getAgentVersion()} http server listening on http://${host}:${port}/mcp`);
+		error(`mobile-mcp ${getAgentVersion()} http server listening on http://${host}:${port}${MCP_ENDPOINT}`);
 	});
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,24 @@
 #!/usr/bin/env node
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { createMcpServer, getAgentVersion } from "./server";
-import { createHttpApp, closeHttpServer, MCP_ENDPOINT } from "./http-server";
+import { createHttpApp, createShutdownHandler, listenHttpServer, MCP_ENDPOINT } from "./http-server";
 import { error } from "./logger";
 import { program } from "commander";
 
 const startHttpServer = async (host: string, port: number) => {
 	const { app, close } = createHttpApp();
 
-	const server = app.listen(port, host, () => {
+	const server = listenHttpServer(app, host, port, () => {
 		error(`mobile-mcp ${getAgentVersion()} http server listening on http://${host}:${port}${MCP_ENDPOINT}`);
+	}, err => {
+		error(`mobile-mcp http server cannot listen on ${host}:${port}: ${err.message}`);
+		process.exit(1);
 	});
 
 	// Release the mcp resources — in-flight modern exchanges and the open sse
-	// stream — before the process goes away, as the stdio entry does.
-	const shutdown = () => {
-		closeHttpServer(server, close).finally(() => process.exit(0));
-	};
+	// streams — before the process goes away, as the stdio entry does. Runs once,
+	// however many signals arrive, and does not wait forever.
+	const shutdown = createShutdownHandler(server, close, () => process.exit(0));
 
 	process.on("SIGINT", shutdown);
 	process.on("SIGTERM", shutdown);

--- a/src/legacy-sse.ts
+++ b/src/legacy-sse.ts
@@ -7,47 +7,65 @@ import { error } from "./logger";
 
 /**
  * The deprecated HTTP+SSE transport (protocol revision 2024-11-05): the client
- * opens a stream with `GET /mcp` and posts messages back to the endpoint the
- * stream advertises, `POST /mcp?sessionId=...`.
+ * opens a stream with `GET`, and posts messages back to the endpoint the stream
+ * advertises, `POST /mcp?sessionId=...`.
  *
  * MCP SDK v2 dropped this transport, so it is served here by the v1 transport
  * implementation, deliberately isolated in this module. Everything else —
  * modern 2026-07-28 traffic and 2025-era Streamable HTTP — is served by the v2
- * entry in `index.ts`, and both share the same tool surface because
- * `createMcpServer` builds it once.
+ * entry, and both share the same tool surface because `createMcpServer` builds
+ * it once.
+ *
+ * The transport owns a dedicated path (`/sse`) rather than sharing `GET /mcp`,
+ * because a shared GET cannot be classified: once a client has learned a
+ * protocol version, an `EventSource` reconnect is byte for byte the listening
+ * GET a Streamable HTTP client opens. Streams are also concurrent here — the
+ * pre-migration single-stream server could be locked out by one misrouted GET,
+ * and nothing routed to this endpoint can now deny another client a stream.
  */
 export interface LegacySseEndpoint {
-	/**
-	 * Whether this GET is a 2024-11-05 stream open rather than the optional
-	 * listening stream a Streamable HTTP client opens after `initialize`.
-	 */
-	isStreamRequest: (req: Request) => boolean;
+	/** Whether this GET resumes a stream this endpoint issued (spec-compliant `Last-Event-ID`). */
+	isStreamResumption: (req: Request) => boolean;
 	/** Whether this POST addresses an HTTP+SSE stream rather than the Streamable HTTP path. */
 	isMessageRequest: (req: Request) => boolean;
-	/** Opens the SSE stream (`GET /mcp`). */
+	/** Opens an SSE stream. */
 	openStream: (req: Request, res: Response) => Promise<void>;
-	/** Delivers a posted message to the open SSE stream (`POST /mcp?sessionId=...`). */
+	/** Delivers a posted message to its stream (`POST /mcp?sessionId=...`). */
 	handleMessage: (req: Request, res: Response) => Promise<void>;
-	/** Tears down the open stream, if any. */
+	/** The number of open streams. */
+	readonly openStreamCount: number;
+	/** Tears down every open stream. */
 	close: () => Promise<void>;
 }
 
 /**
- * Headers a Streamable HTTP client attaches to its optional listening `GET`
- * once a connection is established. The 2024-11-05 client sends neither on the
- * request that opens its stream — it has nothing to report yet — so their
- * presence is what separates the two GETs on a shared endpoint.
+ * Prefix of the last event id stamped on every stream. A spec-compliant
+ * `EventSource` echoes it in `Last-Event-ID` when it reconnects — including
+ * through a redirect — which identifies the request as this transport's beyond
+ * doubt. No Streamable HTTP stream is ever stamped with it, so it cannot
+ * collide.
+ *
+ * SDK v1's own `SSEClientTransport` does not benefit: it hands `EventSource` a
+ * custom `fetch` that replaces the request headers wholesale, dropping the
+ * `Last-Event-ID` the package had put there. Those clients must be pointed at
+ * the dedicated path, where no classification is needed at all.
  */
-const STREAMABLE_HTTP_GET_HEADERS = ["mcp-session-id", "mcp-protocol-version"];
+const STREAM_EVENT_ID_PREFIX = "mobile-mcp-sse-";
+
+/** Concurrent streams this endpoint will hold open. */
+const MAXIMUM_OPEN_STREAMS = 8;
+
+const headerValue = (req: Request, name: string): string | undefined => {
+	const header = req.headers[name];
+	return Array.isArray(header) ? header[0] : header;
+};
 
 export const createLegacySseEndpoint = (endpoint: string): LegacySseEndpoint => {
 
-	// The v1 transport is a single-stream transport, exactly as it was before
-	// the v2 migration: one connected client at a time, 409 for the next one.
-	let transport: SSEServerTransport | null = null;
+	const transports = new Map<string, SSEServerTransport>();
 
-	const isStreamRequest = (req: Request): boolean => {
-		return !STREAMABLE_HTTP_GET_HEADERS.some(header => req.headers[header] !== undefined);
+	const isStreamResumption = (req: Request): boolean => {
+		return headerValue(req, "last-event-id")?.startsWith(STREAM_EVENT_ID_PREFIX) === true;
 	};
 
 	const isMessageRequest = (req: Request): boolean => {
@@ -55,30 +73,30 @@ export const createLegacySseEndpoint = (endpoint: string): LegacySseEndpoint => 
 	};
 
 	const openStream = async (req: Request, res: Response): Promise<void> => {
-		if (transport) {
-			res.status(409).json({ error: "Another client is already connected. Disconnect the existing client first." });
+		if (transports.size >= MAXIMUM_OPEN_STREAMS) {
+			res.status(429).json({ error: `Too many open sse streams (limit ${MAXIMUM_OPEN_STREAMS})` });
 			return;
 		}
 
-		const sseTransport = new SSEServerTransport(endpoint, res);
-		transport = sseTransport;
+		const transport = new SSEServerTransport(endpoint, res);
+		transports.set(transport.sessionId, transport);
 
-		sseTransport.onclose = () => {
-			if (transport === sseTransport) {
-				transport = null;
-			}
+		transport.onclose = () => {
+			transports.delete(transport.sessionId);
 		};
 
 		try {
 			// The v1 transport predates the v2 Transport type but implements the
 			// same start/send/close/onmessage contract the v2 server drives.
 			const server = createMcpServer({ era: "legacy" });
-			await server.connect(sseTransport as unknown as Transport);
-		} catch (err: any) {
-			if (transport === sseTransport) {
-				transport = null;
-			}
+			await server.connect(transport as unknown as Transport);
 
+			// Stamp the stream so a reconnect can identify itself. The event type is
+			// one no MCP client acts on, so it is ignored on arrival and only its id
+			// is remembered.
+			res.write(`id: ${STREAM_EVENT_ID_PREFIX}${transport.sessionId}\nevent: mobile-mcp-stream\ndata: {}\n\n`);
+		} catch (err: any) {
+			transports.delete(transport.sessionId);
 			error(`legacy sse connect failed: ${err.message}`);
 			if (!res.headersSent) {
 				res.status(500).json({ error: "Failed to open the sse stream" });
@@ -87,13 +105,10 @@ export const createLegacySseEndpoint = (endpoint: string): LegacySseEndpoint => 
 	};
 
 	const handleMessage = async (req: Request, res: Response): Promise<void> => {
+		// Only the session an open stream advertised may post to it.
+		const sessionId = req.query.sessionId;
+		const transport = typeof sessionId === "string" ? transports.get(sessionId) : undefined;
 		if (!transport) {
-			res.status(404).json({ error: "No sse stream is open" });
-			return;
-		}
-
-		// Only the session the open stream advertised may post to it.
-		if (req.query.sessionId !== transport.sessionId) {
 			res.status(404).json({ error: "Unknown sse session id" });
 			return;
 		}
@@ -104,10 +119,19 @@ export const createLegacySseEndpoint = (endpoint: string): LegacySseEndpoint => 
 	};
 
 	const close = async (): Promise<void> => {
-		const open = transport;
-		transport = null;
-		await open?.close();
+		const open = [...transports.values()];
+		transports.clear();
+		await Promise.all(open.map(transport => transport.close()));
 	};
 
-	return { isStreamRequest, isMessageRequest, openStream, handleMessage, close };
+	return {
+		isStreamResumption,
+		isMessageRequest,
+		openStream,
+		handleMessage,
+		close,
+		get openStreamCount() {
+			return transports.size;
+		},
+	};
 };

--- a/src/legacy-sse.ts
+++ b/src/legacy-sse.ts
@@ -1,0 +1,90 @@
+import type { Request, Response } from "express";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import type { Transport } from "@modelcontextprotocol/server";
+
+import { createMcpServer } from "./server";
+import { error } from "./logger";
+
+/**
+ * The deprecated HTTP+SSE transport (protocol revision 2024-11-05): the client
+ * opens a stream with `GET /mcp` and posts messages back to the endpoint the
+ * stream advertises, `POST /mcp?sessionId=...`.
+ *
+ * MCP SDK v2 dropped this transport, so it is served here by the v1 transport
+ * implementation, deliberately isolated in this module. Everything else —
+ * modern 2026-07-28 traffic and 2025-era Streamable HTTP — is served by the v2
+ * entry in `index.ts`, and both share the same tool surface because
+ * `createMcpServer` builds it once.
+ */
+export interface LegacySseEndpoint {
+	/** Whether this POST belongs to an open HTTP+SSE stream rather than the Streamable HTTP path. */
+	isSseMessage: (req: Request) => boolean;
+	/** Opens the SSE stream (`GET /mcp`). */
+	openStream: (req: Request, res: Response) => Promise<void>;
+	/** Delivers a posted message to the open SSE stream (`POST /mcp?sessionId=...`). */
+	handleMessage: (req: Request, res: Response) => Promise<void>;
+	/** Tears down the open stream, if any. */
+	close: () => Promise<void>;
+}
+
+export const createLegacySseEndpoint = (endpoint: string): LegacySseEndpoint => {
+
+	// The v1 transport is a single-stream transport, exactly as it was before
+	// the v2 migration: one connected client at a time, 409 for the next one.
+	let transport: SSEServerTransport | null = null;
+
+	const isSseMessage = (req: Request): boolean => {
+		return transport !== null && typeof req.query.sessionId === "string";
+	};
+
+	const openStream = async (req: Request, res: Response): Promise<void> => {
+		if (transport) {
+			res.status(409).json({ error: "Another client is already connected. Disconnect the existing client first." });
+			return;
+		}
+
+		const sseTransport = new SSEServerTransport(endpoint, res);
+		transport = sseTransport;
+
+		sseTransport.onclose = () => {
+			if (transport === sseTransport) {
+				transport = null;
+			}
+		};
+
+		try {
+			// The v1 transport predates the v2 Transport type but implements the
+			// same start/send/close/onmessage contract the v2 server drives.
+			const server = createMcpServer({ era: "legacy" });
+			await server.connect(sseTransport as unknown as Transport);
+		} catch (err: any) {
+			if (transport === sseTransport) {
+				transport = null;
+			}
+
+			error(`legacy sse connect failed: ${err.message}`);
+			if (!res.headersSent) {
+				res.status(500).json({ error: "Failed to open the sse stream" });
+			}
+		}
+	};
+
+	const handleMessage = async (req: Request, res: Response): Promise<void> => {
+		if (!transport) {
+			res.status(404).json({ error: "No sse stream is open" });
+			return;
+		}
+
+		// req.body was already parsed under the endpoint's size limit, so the
+		// transport never reads the request stream itself.
+		await transport.handlePostMessage(req, res, req.body);
+	};
+
+	const close = async (): Promise<void> => {
+		const open = transport;
+		transport = null;
+		await open?.close();
+	};
+
+	return { isSseMessage, openStream, handleMessage, close };
+};

--- a/src/legacy-sse.ts
+++ b/src/legacy-sse.ts
@@ -17,8 +17,13 @@ import { error } from "./logger";
  * `createMcpServer` builds it once.
  */
 export interface LegacySseEndpoint {
-	/** Whether this POST belongs to an open HTTP+SSE stream rather than the Streamable HTTP path. */
-	isSseMessage: (req: Request) => boolean;
+	/**
+	 * Whether this GET is a 2024-11-05 stream open rather than the optional
+	 * listening stream a Streamable HTTP client opens after `initialize`.
+	 */
+	isStreamRequest: (req: Request) => boolean;
+	/** Whether this POST addresses an HTTP+SSE stream rather than the Streamable HTTP path. */
+	isMessageRequest: (req: Request) => boolean;
 	/** Opens the SSE stream (`GET /mcp`). */
 	openStream: (req: Request, res: Response) => Promise<void>;
 	/** Delivers a posted message to the open SSE stream (`POST /mcp?sessionId=...`). */
@@ -27,14 +32,26 @@ export interface LegacySseEndpoint {
 	close: () => Promise<void>;
 }
 
+/**
+ * Headers a Streamable HTTP client attaches to its optional listening `GET`
+ * once a connection is established. The 2024-11-05 client sends neither on the
+ * request that opens its stream — it has nothing to report yet — so their
+ * presence is what separates the two GETs on a shared endpoint.
+ */
+const STREAMABLE_HTTP_GET_HEADERS = ["mcp-session-id", "mcp-protocol-version"];
+
 export const createLegacySseEndpoint = (endpoint: string): LegacySseEndpoint => {
 
 	// The v1 transport is a single-stream transport, exactly as it was before
 	// the v2 migration: one connected client at a time, 409 for the next one.
 	let transport: SSEServerTransport | null = null;
 
-	const isSseMessage = (req: Request): boolean => {
-		return transport !== null && typeof req.query.sessionId === "string";
+	const isStreamRequest = (req: Request): boolean => {
+		return !STREAMABLE_HTTP_GET_HEADERS.some(header => req.headers[header] !== undefined);
+	};
+
+	const isMessageRequest = (req: Request): boolean => {
+		return typeof req.query.sessionId === "string";
 	};
 
 	const openStream = async (req: Request, res: Response): Promise<void> => {
@@ -75,6 +92,12 @@ export const createLegacySseEndpoint = (endpoint: string): LegacySseEndpoint => 
 			return;
 		}
 
+		// Only the session the open stream advertised may post to it.
+		if (req.query.sessionId !== transport.sessionId) {
+			res.status(404).json({ error: "Unknown sse session id" });
+			return;
+		}
+
 		// req.body was already parsed under the endpoint's size limit, so the
 		// transport never reads the request stream itself.
 		await transport.handlePostMessage(req, res, req.body);
@@ -86,5 +109,5 @@ export const createLegacySseEndpoint = (endpoint: string): LegacySseEndpoint => 
 		await open?.close();
 	};
 
-	return { isSseMessage, openStream, handleMessage, close };
+	return { isStreamRequest, isMessageRequest, openStream, handleMessage, close };
 };

--- a/src/legacy-sse.ts
+++ b/src/legacy-sse.ts
@@ -144,8 +144,23 @@ export const createLegacySseEndpoint = (endpoint: string): LegacySseEndpoint => 
 		} catch (err: any) {
 			transports.delete(transport.sessionId);
 			error(`legacy sse connect failed: ${err.message}`);
+
 			if (!res.headersSent) {
 				res.status(500).json({ error: "Failed to open the sse stream" });
+				return;
+			}
+
+			// The stream was already announced, so the failure cannot be reported
+			// in a status code — close it instead, rather than leaving the client
+			// holding a response that will never carry anything.
+			try {
+				await transport.close();
+			} catch (closeErr: any) {
+				error(`legacy sse teardown failed: ${closeErr.message}`);
+			}
+
+			if (!res.writableEnded) {
+				res.end();
 			}
 		}
 	};

--- a/src/legacy-sse.ts
+++ b/src/legacy-sse.ts
@@ -24,8 +24,8 @@ import { error } from "./logger";
  * and nothing routed to this endpoint can now deny another client a stream.
  */
 export interface LegacySseEndpoint {
-	/** Whether this GET resumes a stream this endpoint issued (spec-compliant `Last-Event-ID`). */
-	isStreamResumption: (req: Request) => boolean;
+	/** Whether this GET belongs to the HTTP+SSE transport rather than to Streamable HTTP. */
+	isStreamRequest: (req: Request) => boolean;
 	/** Whether this POST addresses an HTTP+SSE stream rather than the Streamable HTTP path. */
 	isMessageRequest: (req: Request) => boolean;
 	/** Opens an SSE stream. */
@@ -40,32 +40,78 @@ export interface LegacySseEndpoint {
 
 /**
  * Prefix of the last event id stamped on every stream. A spec-compliant
- * `EventSource` echoes it in `Last-Event-ID` when it reconnects — including
- * through a redirect — which identifies the request as this transport's beyond
- * doubt. No Streamable HTTP stream is ever stamped with it, so it cannot
- * collide.
+ * `EventSource` echoes it in `Last-Event-ID` when it re-establishes a stream —
+ * including through a redirect — which identifies the request as this
+ * transport's beyond doubt. No Streamable HTTP stream is ever stamped with it,
+ * so it cannot collide.
  *
- * SDK v1's own `SSEClientTransport` does not benefit: it hands `EventSource` a
+ * SDK v1's own `SSEClientTransport` does not send it: it hands `EventSource` a
  * custom `fetch` that replaces the request headers wholesale, dropping the
- * `Last-Event-ID` the package had put there. Those clients must be pointed at
- * the dedicated path, where no classification is needed at all.
+ * `Last-Event-ID` the package had put there. Those clients are recognised by
+ * their cache signature instead.
  */
 const STREAM_EVENT_ID_PREFIX = "mobile-mcp-sse-";
 
-/** Concurrent streams this endpoint will hold open. */
-const MAXIMUM_OPEN_STREAMS = 8;
+/**
+ * Headers a Streamable HTTP client attaches to the listening GET it opens once
+ * connected. They are only consulted once the HTTP+SSE signals below have been
+ * ruled out — a re-establishing `EventSource` reports a protocol version too.
+ */
+const STREAMABLE_HTTP_GET_HEADERS = ["mcp-session-id", "mcp-protocol-version"];
 
 const headerValue = (req: Request, name: string): string | undefined => {
 	const header = req.headers[name];
 	return Array.isArray(header) ? header[0] : header;
 };
 
+const hasDirective = (value: string | undefined, directives: string[]): boolean => {
+	if (value === undefined) {
+		return false;
+	}
+
+	return value.split(",").some(directive => directives.includes(directive.trim().toLowerCase().split("=")[0]));
+};
+
+/**
+ * Whether a GET carries the cache signature every `EventSource` request has and
+ * no Streamable HTTP request has.
+ *
+ * It is structural rather than incidental: the `eventsource` package issues its
+ * request with fetch cache mode `no-store` (SDK v1's `SSEClientTransport`
+ * replaces only the headers of that request init, so the mode survives), and
+ * the Fetch standard requires a `no-store` request to be given `pragma:
+ * no-cache` and `cache-control: no-cache` in the HTTP-network-or-cache step.
+ * `StreamableHTTPClientTransport` issues its listening GET with the default
+ * cache mode, so it is given neither.
+ *
+ * Either header alone is accepted: an intermediary that drops one must not cost
+ * a client its stream. Matching too eagerly only hands a Streamable HTTP client
+ * a stream it ignores — one of several, and it holds nothing else — while
+ * matching too strictly answers a reconnect with `405` and ends the connection
+ * for good.
+ */
+const hasEventSourceCacheSignature = (req: Request): boolean => {
+	return hasDirective(headerValue(req, "cache-control"), ["no-cache", "no-store"])
+		|| hasDirective(headerValue(req, "pragma"), ["no-cache"]);
+};
+
+/** Concurrent streams this endpoint will hold open. */
+const MAXIMUM_OPEN_STREAMS = 8;
+
 export const createLegacySseEndpoint = (endpoint: string): LegacySseEndpoint => {
 
 	const transports = new Map<string, SSEServerTransport>();
 
-	const isStreamResumption = (req: Request): boolean => {
-		return headerValue(req, "last-event-id")?.startsWith(STREAM_EVENT_ID_PREFIX) === true;
+	const isStreamRequest = (req: Request): boolean => {
+		if (headerValue(req, "last-event-id")?.startsWith(STREAM_EVENT_ID_PREFIX)) {
+			return true;
+		}
+
+		if (hasEventSourceCacheSignature(req)) {
+			return true;
+		}
+
+		return !STREAMABLE_HTTP_GET_HEADERS.some(header => req.headers[header] !== undefined);
 	};
 
 	const isMessageRequest = (req: Request): boolean => {
@@ -91,9 +137,9 @@ export const createLegacySseEndpoint = (endpoint: string): LegacySseEndpoint => 
 			const server = createMcpServer({ era: "legacy" });
 			await server.connect(transport as unknown as Transport);
 
-			// Stamp the stream so a reconnect can identify itself. The event type is
-			// one no MCP client acts on, so it is ignored on arrival and only its id
-			// is remembered.
+			// Stamp the stream so a re-establishing client can identify itself. The
+			// event type is one no MCP client acts on, so it is ignored on arrival
+			// and only its id is remembered.
 			res.write(`id: ${STREAM_EVENT_ID_PREFIX}${transport.sessionId}\nevent: mobile-mcp-stream\ndata: {}\n\n`);
 		} catch (err: any) {
 			transports.delete(transport.sessionId);
@@ -125,7 +171,7 @@ export const createLegacySseEndpoint = (endpoint: string): LegacySseEndpoint => 
 	};
 
 	return {
-		isStreamResumption,
+		isStreamRequest,
 		isMessageRequest,
 		openStream,
 		handleMessage,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer, CLIENT_INFO_META_KEY, PROTOCOL_VERSION_META_KEY } from "@modelcontextprotocol/server";
+import type { CacheHint, McpRequestContext, ServerContext } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import fs from "node:fs";
 import os from "node:os";
@@ -44,22 +45,92 @@ export const getAgentVersion = (): string => {
 	return json.version;
 };
 
-export const createMcpServer = (): McpServer => {
+/**
+ * Cache hints for the 2026-07-28 cacheable results. The tool surface is fixed
+ * for the lifetime of the process, so it is safe for shared caches; every
+ * other cacheable result keeps the conservative `{ ttlMs: 0, cacheScope:
+ * "private" }` default the SDK emits.
+ */
+const CACHE_HINTS: Record<string, CacheHint> = {
+	"server/discover": { ttlMs: 300_000, cacheScope: "public" },
+	"tools/list": { ttlMs: 300_000, cacheScope: "public" },
+};
+
+/**
+ * Application state that must outlive a single MCP request. Modern
+ * (2026-07-28) requests are stateless and self-contained, so a fresh server
+ * instance serves every request: the instance that answers
+ * `mobile_stop_screen_recording` is never the one that started the recording.
+ */
+const mobilecli = new Mobilecli();
+const activeRecordings = new Map<string, ActiveRecording>();
+const agentVerifiedSimulators = new Set<string>();
+const activeLoginProcesses: ChildProcess[] = [];
+
+/** Client identity resolved for a single request, never for a connection. */
+interface RequestClient {
+	name?: string;
+	protocolVersion?: string;
+	era?: string;
+}
+
+const readEnvelope = (ctx?: ServerContext): Record<string, unknown> | undefined => {
+	return ctx?.mcpReq?.envelope as Record<string, unknown> | undefined;
+};
+
+/**
+ * The client name carried by a modern request's `_meta` envelope. The
+ * 2026-07-28 revision has no `initialize`, so client identity is per-request
+ * metadata rather than connection state.
+ */
+export const clientNameFromRequestMeta = (envelope: Record<string, unknown> | undefined): string | undefined => {
+	const clientInfo = envelope?.[CLIENT_INFO_META_KEY];
+	if (clientInfo !== null && typeof clientInfo === "object") {
+		const name = (clientInfo as { name?: unknown }).name;
+		if (typeof name === "string" && name.length > 0) {
+			return name;
+		}
+	}
+
+	return undefined;
+};
+
+/** The protocol revision a modern request declares in its `_meta` envelope. */
+export const protocolVersionFromRequestMeta = (envelope: Record<string, unknown> | undefined): string | undefined => {
+	const version = envelope?.[PROTOCOL_VERSION_META_KEY];
+	return typeof version === "string" && version.length > 0 ? version : undefined;
+};
+
+let launchReported = false;
+
+export const createMcpServer = (context?: McpRequestContext): McpServer => {
 
 	const server = new McpServer({
 		name: "mobile-mcp",
 		version: getAgentVersion(),
+	}, {
+		cacheHints: CACHE_HINTS,
 	});
 
-
-	const getClientName = (): string => {
+	/**
+	 * Legacy (2025-era) connections still learn the client from the
+	 * `initialize` handshake; modern requests never do.
+	 */
+	const getLegacyClientName = (): string | undefined => {
 		try {
-			const clientInfo = server.server.getClientVersion();
-			const clientName = clientInfo?.name || "unknown";
-			return clientName;
+			return server.server.getClientVersion()?.name || undefined;
 		} catch (error: any) {
-			return "unknown";
+			return undefined;
 		}
+	};
+
+	const getRequestClient = (ctx?: ServerContext): RequestClient => {
+		const envelope = readEnvelope(ctx);
+		return {
+			name: clientNameFromRequestMeta(envelope) || getLegacyClientName(),
+			protocolVersion: protocolVersionFromRequestMeta(envelope),
+			era: context?.era,
+		};
 	};
 
 	type ZodSchemaShape = Record<string, z.ZodType>;
@@ -75,7 +146,8 @@ export const createMcpServer = (): McpServer => {
 			description,
 			inputSchema: paramsSchema,
 			annotations,
-		}, (async (args: any, _extra: any) => {
+		}, (async (args: any, extra: any) => {
+			const client = getRequestClient(extra);
 			try {
 				trace(`Invoking ${name} with args: ${JSON.stringify(args)}`);
 				const start = +new Date();
@@ -83,12 +155,12 @@ export const createMcpServer = (): McpServer => {
 				const response = await cb(args, telemetry);
 				const duration = +new Date() - start;
 				trace(`=> ${response}`);
-				posthog("tool_invoked", { "ToolName": name, "Duration": duration, ...telemetry }).then();
+				posthog("tool_invoked", { "ToolName": name, "Duration": duration, ...telemetry }, client).then();
 				return {
 					content: [{ type: "text", text: response }],
 				};
 			} catch (error: any) {
-				posthog("tool_failed", { "ToolName": name }).then();
+				posthog("tool_failed", { "ToolName": name }, client).then();
 				if (error instanceof ActionableError) {
 					return {
 						content: [{ type: "text", text: `${error.message}. Please fix the issue and try again.` }],
@@ -105,7 +177,7 @@ export const createMcpServer = (): McpServer => {
 		}) as any);
 	};
 
-	const posthog = async (event: string, properties: Record<string, string | number>) => {
+	const posthog = async (event: string, properties: Record<string, string | number>, client?: RequestClient) => {
 		if (process.env.MOBILEMCP_DISABLE_TELEMETRY) {
 			return;
 		}
@@ -124,9 +196,16 @@ export const createMcpServer = (): McpServer => {
 				RobotMode: process.env.MOBILEMCP_LEGACY_ROBOT === "1" ? "legacy" : "mobilecli",
 			};
 
-			const clientName = getClientName();
-			if (clientName !== "unknown") {
-				systemProps.AgentName = clientName;
+			if (client?.name) {
+				systemProps.AgentName = client.name;
+			}
+
+			if (client?.protocolVersion) {
+				systemProps.ProtocolVersion = client.protocolVersion;
+			}
+
+			if (client?.era) {
+				systemProps.ProtocolEra = client.era;
 			}
 
 			await fetch(url, {
@@ -149,11 +228,11 @@ export const createMcpServer = (): McpServer => {
 		}
 	};
 
-	const mobilecli = new Mobilecli();
-	const activeRecordings = new Map<string, ActiveRecording>();
-	const agentVerifiedSimulators = new Set<string>();
-	const activeLoginProcesses: ChildProcess[] = [];
-	posthog("launch", {}).then();
+	// one launch event per process, the factory is now called per request
+	if (!launchReported) {
+		launchReported = true;
+		posthog("launch", {}).then();
+	}
 
 	const ensureMobilecliAvailable = (): void => {
 		try {
@@ -752,7 +831,7 @@ export const createMcpServer = (): McpServer => {
 				readOnlyHint: true,
 			},
 		},
-		async ({ device }) => {
+		async ({ device }, extra) => {
 			try {
 				const robot = getRobotFromDevice(device);
 				const screenSize = await robot.getScreenSize();
@@ -789,7 +868,7 @@ export const createMcpServer = (): McpServer => {
 					"ScreenshotMimeType": mimeType,
 					"ScreenshotWidth": pngSize.width,
 					"ScreenshotHeight": pngSize.height,
-				}).then();
+				}, getRequestClient(extra)).then();
 
 				return {
 					content: [{ type: "image", data: screenshot64, mimeType }]

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import crypto from "node:crypto";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { ChildProcess } from "node:child_process";
 
 import { error, trace } from "./logger";
@@ -73,6 +74,16 @@ interface RequestClient {
 	protocolVersion?: string;
 	era?: string;
 }
+
+/**
+ * The client of the request currently being served. Telemetry raised deeper in
+ * a tool invocation (`get_robot`, for instance) has no access to the handler
+ * context, so the resolved identity travels with the async context instead of
+ * through every intermediate signature. A store per invocation keeps
+ * attribution correct when a single server instance serves concurrent
+ * requests, which is what a legacy stdio connection does.
+ */
+const requestClientStorage = new AsyncLocalStorage<RequestClient>();
 
 const readEnvelope = (ctx?: ServerContext): Record<string, unknown> | undefined => {
 	return ctx?.mcpReq?.envelope as Record<string, unknown> | undefined;
@@ -148,39 +159,43 @@ export const createMcpServer = (context?: McpRequestContext): McpServer => {
 			annotations,
 		}, (async (args: any, extra: any) => {
 			const client = getRequestClient(extra);
-			try {
-				trace(`Invoking ${name} with args: ${JSON.stringify(args)}`);
-				const start = +new Date();
-				const telemetry: Record<string, string | number> = {};
-				const response = await cb(args, telemetry);
-				const duration = +new Date() - start;
-				trace(`=> ${response}`);
-				posthog("tool_invoked", { "ToolName": name, "Duration": duration, ...telemetry }, client).then();
-				return {
-					content: [{ type: "text", text: response }],
-				};
-			} catch (error: any) {
-				posthog("tool_failed", { "ToolName": name }, client).then();
-				if (error instanceof ActionableError) {
+			return requestClientStorage.run(client, async () => {
+				try {
+					trace(`Invoking ${name} with args: ${JSON.stringify(args)}`);
+					const start = +new Date();
+					const telemetry: Record<string, string | number> = {};
+					const response = await cb(args, telemetry);
+					const duration = +new Date() - start;
+					trace(`=> ${response}`);
+					posthog("tool_invoked", { "ToolName": name, "Duration": duration, ...telemetry }).then();
 					return {
-						content: [{ type: "text", text: `${error.message}. Please fix the issue and try again.` }],
+						content: [{ type: "text", text: response }],
 					};
-				} else {
-					// a real exception
-					trace(`Tool '${description}' failed: ${error.message} stack: ${error.stack}`);
-					return {
-						content: [{ type: "text", text: `Error: ${error.message}` }],
-						isError: true,
-					};
+				} catch (error: any) {
+					posthog("tool_failed", { "ToolName": name }).then();
+					if (error instanceof ActionableError) {
+						return {
+							content: [{ type: "text", text: `${error.message}. Please fix the issue and try again.` }],
+						};
+					} else {
+						// a real exception
+						trace(`Tool '${description}' failed: ${error.message} stack: ${error.stack}`);
+						return {
+							content: [{ type: "text", text: `Error: ${error.message}` }],
+							isError: true,
+						};
+					}
 				}
-			}
+			});
 		}) as any);
 	};
 
-	const posthog = async (event: string, properties: Record<string, string | number>, client?: RequestClient) => {
+	const posthog = async (event: string, properties: Record<string, string | number>, explicitClient?: RequestClient) => {
 		if (process.env.MOBILEMCP_DISABLE_TELEMETRY) {
 			return;
 		}
+
+		const client = explicitClient || requestClientStorage.getStore();
 
 		try {
 			const url = "https://us.i.posthog.com/i/v0/e/";
@@ -831,7 +846,7 @@ export const createMcpServer = (context?: McpRequestContext): McpServer => {
 				readOnlyHint: true,
 			},
 		},
-		async ({ device }, extra) => {
+		async ({ device }, extra) => requestClientStorage.run(getRequestClient(extra), async () => {
 			try {
 				const robot = getRobotFromDevice(device);
 				const screenSize = await robot.getScreenSize();
@@ -868,7 +883,7 @@ export const createMcpServer = (context?: McpRequestContext): McpServer => {
 					"ScreenshotMimeType": mimeType,
 					"ScreenshotWidth": pngSize.width,
 					"ScreenshotHeight": pngSize.height,
-				}, getRequestClient(extra)).then();
+				}).then();
 
 				return {
 					content: [{ type: "image", data: screenshot64, mimeType }]
@@ -880,7 +895,7 @@ export const createMcpServer = (context?: McpRequestContext): McpServer => {
 					isError: true,
 				};
 			}
-		}
+		})
 	);
 
 	tool(

--- a/test/mcp-http-transport.test.ts
+++ b/test/mcp-http-transport.test.ts
@@ -1,0 +1,361 @@
+import { test, expect } from "@playwright/test";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import {
+	CLIENT_CAPABILITIES_META_KEY,
+	CLIENT_INFO_META_KEY,
+	PROTOCOL_VERSION_META_KEY,
+} from "@modelcontextprotocol/server";
+
+import { createHttpApp } from "../src/http-server";
+import { Mobilecli } from "../src/mobilecli";
+
+process.env.MOBILEMCP_DISABLE_TELEMETRY = "1";
+
+const MODERN_PROTOCOL_VERSION = "2026-07-28";
+const LEGACY_PROTOCOL_VERSION = "2025-06-18";
+const MAXIMUM_MESSAGE_SIZE = 4 * 1024 * 1024;
+
+interface RunningServer {
+	url: string;
+	port: number;
+	stop: () => Promise<void>;
+}
+
+const startServer = async (): Promise<RunningServer> => {
+	const { app, close } = createHttpApp();
+	const server = await new Promise<http.Server>(resolve => {
+		const listening = app.listen(0, "127.0.0.1", () => resolve(listening));
+	});
+
+	const port = (server.address() as AddressInfo).port;
+
+	return {
+		url: `http://127.0.0.1:${port}/mcp`,
+		port,
+		stop: async () => {
+			await close();
+			await new Promise<void>(resolve => server.close(() => resolve()));
+		},
+	};
+};
+
+const modernEnvelope = (clientName: string = "mobile-mcp-tests") => ({
+	[PROTOCOL_VERSION_META_KEY]: MODERN_PROTOCOL_VERSION,
+	[CLIENT_INFO_META_KEY]: { name: clientName, version: "1.2.3" },
+	[CLIENT_CAPABILITIES_META_KEY]: {},
+});
+
+test.describe("mcp http transport", () => {
+
+	test.describe("request body limit", () => {
+		test("should reject a body larger than 4mb with 413", async () => {
+			const server = await startServer();
+			try {
+				const oversized = JSON.stringify({
+					jsonrpc: "2.0",
+					id: 1,
+					method: "tools/list",
+					params: { _meta: modernEnvelope(), pad: "x".repeat(5 * 1024 * 1024) },
+				});
+				expect(oversized.length).toBeGreaterThan(MAXIMUM_MESSAGE_SIZE);
+
+				const response = await fetch(server.url, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: oversized,
+				});
+
+				expect(response.status).toBe(413);
+				const body = await response.json() as any;
+				expect(body.error.message).toContain("Payload Too Large");
+				// the request never reached the mcp server
+				expect(body.result).toBeUndefined();
+			} finally {
+				await server.stop();
+			}
+		});
+
+		test("should reject an oversized body without buffering it", async () => {
+			const server = await startServer();
+			let request: http.ClientRequest | undefined;
+
+			try {
+				const declaredLength = 64 * 1024 * 1024;
+				let bytesWritten = 0;
+
+				const status = await new Promise<number>((resolve, reject) => {
+					request = http.request({
+						host: "127.0.0.1",
+						port: server.port,
+						path: "/mcp",
+						method: "POST",
+						headers: {
+							"content-type": "application/json",
+							"content-length": String(declaredLength),
+						},
+					});
+
+					request.on("response", response => {
+						response.resume();
+						resolve(response.statusCode ?? 0);
+					});
+
+					// the socket is torn down once the request is refused, which must
+					// not fail the test
+					request.on("error", error => {
+						if (bytesWritten === 0) {
+							reject(error);
+						}
+					});
+
+					const chunk = "x".repeat(1024);
+					request.write(chunk);
+					bytesWritten += chunk.length;
+
+					setTimeout(() => reject(new Error("no response to the oversized request")), 10_000);
+				});
+
+				// the declared length is refused up front, so the body is never read:
+				// only the 1kb probe chunk was ever put on the wire
+				expect(status).toBe(413);
+				expect(bytesWritten).toBe(1024);
+			} finally {
+				request?.destroy();
+				await server.stop();
+			}
+		});
+
+		test("should reject an oversized chunked body that declares no length", async () => {
+			const server = await startServer();
+			try {
+				const payload = "x".repeat(5 * 1024 * 1024);
+				const body = new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(new TextEncoder().encode(`{"pad":"${payload}"}`));
+						controller.close();
+					},
+				});
+
+				const response = await fetch(server.url, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body,
+					duplex: "half",
+				} as RequestInit);
+
+				expect(response.status).toBe(413);
+				const parsed = await response.json() as any;
+				expect(parsed.error.message).toContain("Payload Too Large");
+			} finally {
+				await server.stop();
+			}
+		});
+
+		test("should still serve an ordinary modern request", async () => {
+			const server = await startServer();
+			try {
+				const response = await fetch(server.url, {
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						"accept": "application/json, text/event-stream",
+						"MCP-Protocol-Version": MODERN_PROTOCOL_VERSION,
+						"Mcp-Method": "server/discover",
+					},
+					body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "server/discover", params: { _meta: modernEnvelope() } }),
+				});
+
+				expect(response.status).toBe(200);
+				const body = await response.json() as any;
+				expect(body.result.supportedVersions).toEqual([MODERN_PROTOCOL_VERSION]);
+			} finally {
+				await server.stop();
+			}
+		});
+
+		test("should still serve an ordinary legacy streamable http request", async () => {
+			const server = await startServer();
+			try {
+				const response = await fetch(server.url, {
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						"accept": "application/json, text/event-stream",
+					},
+					body: JSON.stringify({
+						jsonrpc: "2.0",
+						id: 1,
+						method: "initialize",
+						params: {
+							protocolVersion: LEGACY_PROTOCOL_VERSION,
+							capabilities: {},
+							clientInfo: { name: "legacy-client", version: "0.1.0" },
+						},
+					}),
+				});
+
+				expect(response.status).toBe(200);
+				const text = await response.text();
+				expect(text).toContain(`"protocolVersion":"${LEGACY_PROTOCOL_VERSION}"`);
+			} finally {
+				await server.stop();
+			}
+		});
+
+		test("should answer an unparsable body with a json-rpc parse error", async () => {
+			const server = await startServer();
+			try {
+				const response = await fetch(server.url, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: "{ not json",
+				});
+
+				expect(response.status).toBe(400);
+				const body = await response.json() as any;
+				expect(body.error.code).toBe(-32700);
+			} finally {
+				await server.stop();
+			}
+		});
+	});
+
+	test.describe("legacy http+sse transport", () => {
+		test("should serve the deprecated sse transport on GET /mcp", async () => {
+			const server = await startServer();
+			const client = new Client({ name: "sse-regression", version: "1.0.0" });
+
+			try {
+				await client.connect(new SSEClientTransport(new URL(server.url)));
+
+				expect(client.getServerVersion()?.name).toBe("mobile-mcp");
+
+				const tools = await client.listTools();
+				const toolNames = tools.tools.map(tool => tool.name);
+				expect(toolNames).toContain("mobile_list_available_devices");
+				expect(toolNames).toContain("mobile_take_screenshot");
+			} finally {
+				await client.close();
+				await server.stop();
+			}
+		});
+
+		test("should refuse a second concurrent sse stream", async () => {
+			const server = await startServer();
+			const client = new Client({ name: "sse-regression", version: "1.0.0" });
+
+			try {
+				await client.connect(new SSEClientTransport(new URL(server.url)));
+
+				const second = await fetch(server.url, { headers: { accept: "text/event-stream" } });
+				expect(second.status).toBe(409);
+				await second.body?.cancel();
+			} finally {
+				await client.close();
+				await server.stop();
+			}
+		});
+
+		test("should not route a modern post to the sse stream", async () => {
+			const server = await startServer();
+			const client = new Client({ name: "sse-regression", version: "1.0.0" });
+
+			try {
+				await client.connect(new SSEClientTransport(new URL(server.url)));
+
+				const response = await fetch(server.url, {
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						"accept": "application/json, text/event-stream",
+						"MCP-Protocol-Version": MODERN_PROTOCOL_VERSION,
+						"Mcp-Method": "server/discover",
+					},
+					body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "server/discover", params: { _meta: modernEnvelope() } }),
+				});
+
+				expect(response.status).toBe(200);
+				const body = await response.json() as any;
+				expect(body.result.supportedVersions).toEqual([MODERN_PROTOCOL_VERSION]);
+			} finally {
+				await client.close();
+				await server.stop();
+			}
+		});
+	});
+
+	test.describe("telemetry attribution", () => {
+		test("should attribute get_robot events to the requesting client", async () => {
+			const events: any[] = [];
+			const originalFetch = globalThis.fetch;
+			const originalGetVersion = Mobilecli.prototype.getVersion;
+			const originalGetDevices = Mobilecli.prototype.getDevices;
+
+			Mobilecli.prototype.getVersion = () => "1.0.0";
+			Mobilecli.prototype.getDevices = () => ({
+				status: "ok",
+				data: {
+					devices: [{
+						id: "telemetry-device",
+						name: "Telemetry Device",
+						platform: "android",
+						type: "emulator",
+						version: "14",
+						state: "online",
+					}],
+				},
+			}) as any;
+
+			globalThis.fetch = (async (input: any, init: any) => {
+				if (typeof input === "string" && input.includes("posthog.com")) {
+					events.push(JSON.parse(init.body));
+					return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+				}
+
+				return originalFetch(input, init);
+			}) as typeof fetch;
+			delete process.env.MOBILEMCP_DISABLE_TELEMETRY;
+
+			const server = await startServer();
+			try {
+				await fetch(server.url, {
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						"accept": "application/json, text/event-stream",
+						"MCP-Protocol-Version": MODERN_PROTOCOL_VERSION,
+						"Mcp-Method": "tools/call",
+						"Mcp-Name": "mobile_get_orientation",
+					},
+					body: JSON.stringify({
+						jsonrpc: "2.0",
+						id: 1,
+						method: "tools/call",
+						params: {
+							name: "mobile_get_orientation",
+							arguments: { device: "telemetry-device" },
+							_meta: modernEnvelope("windsurf"),
+						},
+					}),
+				});
+
+				await expect.poll(() => events.filter(event => event.event === "get_robot").length, { timeout: 5000 }).toBeGreaterThan(0);
+
+				const robotEvent = events.find(event => event.event === "get_robot");
+				expect(robotEvent.properties.DevicePlatform).toBe("android");
+				expect(robotEvent.properties.AgentName).toBe("windsurf");
+				expect(robotEvent.properties.ProtocolVersion).toBe(MODERN_PROTOCOL_VERSION);
+				expect(robotEvent.properties.ProtocolEra).toBe("modern");
+			} finally {
+				await server.stop();
+				process.env.MOBILEMCP_DISABLE_TELEMETRY = "1";
+				globalThis.fetch = originalFetch;
+				Mobilecli.prototype.getVersion = originalGetVersion;
+				Mobilecli.prototype.getDevices = originalGetDevices;
+			}
+		});
+	});
+});

--- a/test/mcp-http-transport.test.ts
+++ b/test/mcp-http-transport.test.ts
@@ -21,7 +21,9 @@ const MAXIMUM_MESSAGE_SIZE = 4 * 1024 * 1024;
 
 interface RunningServer {
 	url: string;
+	sseUrl: string;
 	port: number;
+	server: http.Server;
 	stop: () => Promise<void>;
 }
 
@@ -35,9 +37,27 @@ const startServer = async (): Promise<RunningServer> => {
 
 	return {
 		url: `http://127.0.0.1:${port}/mcp`,
+		sseUrl: `http://127.0.0.1:${port}/sse`,
 		port,
+		server,
 		stop: () => closeHttpServer(server, close),
 	};
+};
+
+/** Polls until the client's transport works again, as a reconnect is asynchronous. */
+const waitUntilUsable = async (client: Client, timeoutMs: number): Promise<boolean> => {
+	const startedAt = Date.now();
+	while (Date.now() - startedAt < timeoutMs) {
+		try {
+			if ((await client.listTools()).tools.length > 0) {
+				return true;
+			}
+		} catch (err: any) {
+			await new Promise(resolve => setTimeout(resolve, 250));
+		}
+	}
+
+	return false;
 };
 
 const modernEnvelope = (clientName: string = "mobile-mcp-tests") => ({
@@ -222,12 +242,12 @@ test.describe("mcp http transport", () => {
 	});
 
 	test.describe("legacy http+sse transport", () => {
-		test("should serve the deprecated sse transport on GET /mcp", async () => {
+		test("should serve the deprecated sse transport on its own path", async () => {
 			const server = await startServer();
 			const client = new Client({ name: "sse-regression", version: "1.0.0" });
 
 			try {
-				await client.connect(new SSEClientTransport(new URL(server.url)));
+				await client.connect(new SSEClientTransport(new URL(server.sseUrl)));
 
 				expect(client.getServerVersion()?.name).toBe("mobile-mcp");
 
@@ -241,18 +261,119 @@ test.describe("mcp http transport", () => {
 			}
 		});
 
-		test("should refuse a second concurrent sse stream", async () => {
+		test("should redirect a bare GET /mcp to the sse path permanently", async () => {
+			const server = await startServer();
+			try {
+				const response = await fetch(server.url, {
+					headers: { accept: "text/event-stream" },
+					redirect: "manual",
+				});
+
+				expect(response.status).toBe(301);
+				expect(response.headers.get("location")).toBe("/sse");
+				await response.body?.cancel();
+			} finally {
+				await server.stop();
+			}
+		});
+
+		test("should serve a client configured at /mcp through the redirect", async () => {
 			const server = await startServer();
 			const client = new Client({ name: "sse-regression", version: "1.0.0" });
 
 			try {
 				await client.connect(new SSEClientTransport(new URL(server.url)));
 
-				const second = await fetch(server.url, { headers: { accept: "text/event-stream" } });
-				expect(second.status).toBe(409);
-				await second.body?.cancel();
+				expect(client.getServerVersion()?.name).toBe("mobile-mcp");
+				const tools = await client.listTools();
+				expect(tools.tools.length).toBeGreaterThan(0);
+
+				// tool calls travel on the advertised POST endpoint
+				const result = await client.callTool({ name: "mobile_list_available_devices", arguments: {} }) as any;
+				expect(result.content[0].type).toBe("text");
 			} finally {
 				await client.close();
+				await server.stop();
+			}
+		});
+
+		test("should reconnect automatically after its stream is dropped", async () => {
+			const server = await startServer();
+			const client = new Client({ name: "sse-regression", version: "1.0.0" });
+
+			try {
+				await client.connect(new SSEClientTransport(new URL(server.sseUrl)));
+				expect((await client.listTools()).tools.length).toBeGreaterThan(0);
+
+				// forcibly drop the sse response, as a proxy or a network blip would
+				server.server.closeAllConnections();
+
+				// the client re-establishes the stream on its own, receives a fresh
+				// endpoint event, and is usable again without reconnecting by hand
+				expect(await waitUntilUsable(client, 30_000)).toBe(true);
+			} finally {
+				await client.close();
+				await server.stop();
+			}
+		});
+
+		test("should serve concurrent sse streams", async () => {
+			const server = await startServer();
+			const first = new Client({ name: "sse-first", version: "1.0.0" });
+			const second = new Client({ name: "sse-second", version: "1.0.0" });
+
+			try {
+				await first.connect(new SSEClientTransport(new URL(server.sseUrl)));
+				await second.connect(new SSEClientTransport(new URL(server.sseUrl)));
+
+				// no single slot means no client can lock another one out
+				expect((await first.listTools()).tools.length).toBeGreaterThan(0);
+				expect((await second.listTools()).tools.length).toBeGreaterThan(0);
+			} finally {
+				await second.close();
+				await first.close();
+				await server.stop();
+			}
+		});
+
+		test("should serve a GET carrying our stream marker wherever it arrives", async () => {
+			const server = await startServer();
+			try {
+				// a spec-compliant EventSource resumes with the id the stream stamped,
+				// even while reporting a protocol version
+				const response = await fetch(server.url, {
+					headers: {
+						"accept": "text/event-stream",
+						"mcp-protocol-version": LEGACY_PROTOCOL_VERSION,
+						"last-event-id": "mobile-mcp-sse-any-previous-session",
+					},
+					redirect: "manual",
+				});
+
+				expect(response.status).toBe(200);
+				expect(response.headers.get("content-type")).toContain("text/event-stream");
+				await response.body?.cancel();
+			} finally {
+				await server.stop();
+			}
+		});
+
+		test("should refuse streams beyond the concurrency limit", async () => {
+			const server = await startServer();
+			const streams: Response[] = [];
+
+			try {
+				for (let index = 0; index < 8; index++) {
+					const stream = await fetch(server.sseUrl, { headers: { accept: "text/event-stream" } });
+					expect(stream.status).toBe(200);
+					streams.push(stream);
+				}
+
+				const beyondLimit = await fetch(server.sseUrl, { headers: { accept: "text/event-stream" } });
+				expect(beyondLimit.status).toBe(429);
+				await beyondLimit.body?.cancel();
+			} finally {
+				await Promise.all(streams.map(stream => stream.body?.cancel()));
 				await server.stop();
 			}
 		});
@@ -262,7 +383,7 @@ test.describe("mcp http transport", () => {
 			const client = new Client({ name: "sse-regression", version: "1.0.0" });
 
 			try {
-				await client.connect(new SSEClientTransport(new URL(server.url)));
+				await client.connect(new SSEClientTransport(new URL(server.sseUrl)));
 
 				const response = await fetch(server.url, {
 					method: "POST",
@@ -289,7 +410,7 @@ test.describe("mcp http transport", () => {
 			const client = new Client({ name: "sse-regression", version: "1.0.0" });
 
 			try {
-				await client.connect(new SSEClientTransport(new URL(server.url)));
+				await client.connect(new SSEClientTransport(new URL(server.sseUrl)));
 
 				const response = await fetch(`${server.url}?sessionId=not-the-open-session`, {
 					method: "POST",
@@ -309,7 +430,7 @@ test.describe("mcp http transport", () => {
 		test("should accept a post carrying the advertised sse session id", async () => {
 			const server = await startServer();
 			try {
-				const stream = await fetch(server.url, { headers: { accept: "text/event-stream" } });
+				const stream = await fetch(server.sseUrl, { headers: { accept: "text/event-stream" } });
 				const reader = stream.body!.getReader();
 				const announcement = new TextDecoder().decode((await reader.read()).value);
 				const sessionId = new URL(announcement.split("data: ")[1].trim(), server.url).searchParams.get("sessionId");
@@ -341,19 +462,19 @@ test.describe("mcp http transport", () => {
 	});
 
 	test.describe("streamable http and legacy sse coexistence", () => {
-		test("should not let a streamable http client occupy the legacy sse slot", async () => {
+		test("should not let a streamable http client occupy an sse stream", async () => {
 			const server = await startServer();
 			const streamableClient = new Client({ name: "streamable-regression", version: "1.0.0" });
 			const sseClient = new Client({ name: "sse-regression", version: "1.0.0" });
 
 			try {
 				// a v1 streamable http client opens its optional listening GET right
-				// after connecting; that GET must not take the single sse slot
+				// after connecting; that GET must never become an http+sse stream
 				await streamableClient.connect(new StreamableHTTPClientTransport(new URL(server.url)));
 				expect(streamableClient.getServerVersion()?.name).toBe("mobile-mcp");
 
-				// the genuine 2024-11-05 client can still open the stream
-				await sseClient.connect(new SSEClientTransport(new URL(server.url)));
+				// the genuine 2024-11-05 client still gets its stream
+				await sseClient.connect(new SSEClientTransport(new URL(server.sseUrl)));
 				expect(sseClient.getServerVersion()?.name).toBe("mobile-mcp");
 
 				// and both keep working side by side
@@ -373,9 +494,11 @@ test.describe("mcp http transport", () => {
 			try {
 				const withProtocolVersion = await fetch(server.url, {
 					headers: { "accept": "text/event-stream", "mcp-protocol-version": LEGACY_PROTOCOL_VERSION },
+					redirect: "manual",
 				});
 				const withSessionId = await fetch(server.url, {
 					headers: { "accept": "text/event-stream", "mcp-session-id": "some-session" },
+					redirect: "manual",
 				});
 
 				expect(withProtocolVersion.status).toBe(405);
@@ -383,8 +506,8 @@ test.describe("mcp http transport", () => {
 				await withProtocolVersion.body?.cancel();
 				await withSessionId.body?.cancel();
 
-				// and the legacy slot is still free afterwards
-				const stream = await fetch(server.url, { headers: { accept: "text/event-stream" } });
+				// and the sse path is untouched by them
+				const stream = await fetch(server.sseUrl, { headers: { accept: "text/event-stream" } });
 				expect(stream.status).toBe(200);
 				expect(stream.headers.get("content-type")).toContain("text/event-stream");
 				await stream.body?.cancel();
@@ -403,7 +526,7 @@ test.describe("mcp http transport", () => {
 
 			const port = (server.address() as AddressInfo).port;
 			const client = new Client({ name: "shutdown-regression", version: "1.0.0" });
-			await client.connect(new SSEClientTransport(new URL(`http://127.0.0.1:${port}/mcp`)));
+			await client.connect(new SSEClientTransport(new URL(`http://127.0.0.1:${port}/sse`)));
 
 			// an open sse stream would otherwise hold the listener open forever
 			await closeHttpServer(server, close);

--- a/test/mcp-http-transport.test.ts
+++ b/test/mcp-http-transport.test.ts
@@ -3,13 +3,14 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import {
 	CLIENT_CAPABILITIES_META_KEY,
 	CLIENT_INFO_META_KEY,
 	PROTOCOL_VERSION_META_KEY,
 } from "@modelcontextprotocol/server";
 
-import { createHttpApp } from "../src/http-server";
+import { createHttpApp, closeHttpServer } from "../src/http-server";
 import { Mobilecli } from "../src/mobilecli";
 
 process.env.MOBILEMCP_DISABLE_TELEMETRY = "1";
@@ -35,10 +36,7 @@ const startServer = async (): Promise<RunningServer> => {
 	return {
 		url: `http://127.0.0.1:${port}/mcp`,
 		port,
-		stop: async () => {
-			await close();
-			await new Promise<void>(resolve => server.close(() => resolve()));
-		},
+		stop: () => closeHttpServer(server, close),
 	};
 };
 
@@ -284,6 +282,136 @@ test.describe("mcp http transport", () => {
 				await client.close();
 				await server.stop();
 			}
+		});
+
+		test("should reject a post carrying an unknown sse session id", async () => {
+			const server = await startServer();
+			const client = new Client({ name: "sse-regression", version: "1.0.0" });
+
+			try {
+				await client.connect(new SSEClientTransport(new URL(server.url)));
+
+				const response = await fetch(`${server.url}?sessionId=not-the-open-session`, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+				});
+
+				expect(response.status).toBe(404);
+				const body = await response.json() as any;
+				expect(body.error).toBe("Unknown sse session id");
+			} finally {
+				await client.close();
+				await server.stop();
+			}
+		});
+
+		test("should accept a post carrying the advertised sse session id", async () => {
+			const server = await startServer();
+			try {
+				const stream = await fetch(server.url, { headers: { accept: "text/event-stream" } });
+				const reader = stream.body!.getReader();
+				const announcement = new TextDecoder().decode((await reader.read()).value);
+				const sessionId = new URL(announcement.split("data: ")[1].trim(), server.url).searchParams.get("sessionId");
+
+				expect(sessionId).toBeTruthy();
+
+				const response = await fetch(`${server.url}?sessionId=${sessionId}`, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({
+						jsonrpc: "2.0",
+						id: 1,
+						method: "initialize",
+						params: {
+							protocolVersion: "2024-11-05",
+							capabilities: {},
+							clientInfo: { name: "raw-sse-client", version: "1.0.0" },
+						},
+					}),
+				});
+
+				expect(response.status).toBe(202);
+
+				await reader.cancel();
+			} finally {
+				await server.stop();
+			}
+		});
+	});
+
+	test.describe("streamable http and legacy sse coexistence", () => {
+		test("should not let a streamable http client occupy the legacy sse slot", async () => {
+			const server = await startServer();
+			const streamableClient = new Client({ name: "streamable-regression", version: "1.0.0" });
+			const sseClient = new Client({ name: "sse-regression", version: "1.0.0" });
+
+			try {
+				// a v1 streamable http client opens its optional listening GET right
+				// after connecting; that GET must not take the single sse slot
+				await streamableClient.connect(new StreamableHTTPClientTransport(new URL(server.url)));
+				expect(streamableClient.getServerVersion()?.name).toBe("mobile-mcp");
+
+				// the genuine 2024-11-05 client can still open the stream
+				await sseClient.connect(new SSEClientTransport(new URL(server.url)));
+				expect(sseClient.getServerVersion()?.name).toBe("mobile-mcp");
+
+				// and both keep working side by side
+				const streamableTools = await streamableClient.listTools();
+				const sseTools = await sseClient.listTools();
+				expect(streamableTools.tools.length).toBeGreaterThan(0);
+				expect(sseTools.tools.length).toBe(streamableTools.tools.length);
+			} finally {
+				await sseClient.close();
+				await streamableClient.close();
+				await server.stop();
+			}
+		});
+
+		test("should answer a streamable http listening stream with 405", async () => {
+			const server = await startServer();
+			try {
+				const withProtocolVersion = await fetch(server.url, {
+					headers: { "accept": "text/event-stream", "mcp-protocol-version": LEGACY_PROTOCOL_VERSION },
+				});
+				const withSessionId = await fetch(server.url, {
+					headers: { "accept": "text/event-stream", "mcp-session-id": "some-session" },
+				});
+
+				expect(withProtocolVersion.status).toBe(405);
+				expect(withSessionId.status).toBe(405);
+				await withProtocolVersion.body?.cancel();
+				await withSessionId.body?.cancel();
+
+				// and the legacy slot is still free afterwards
+				const stream = await fetch(server.url, { headers: { accept: "text/event-stream" } });
+				expect(stream.status).toBe(200);
+				expect(stream.headers.get("content-type")).toContain("text/event-stream");
+				await stream.body?.cancel();
+			} finally {
+				await server.stop();
+			}
+		});
+	});
+
+	test.describe("shutdown", () => {
+		test("should release the handler and an open sse stream", async () => {
+			const { app, close } = createHttpApp();
+			const server = await new Promise<http.Server>(resolve => {
+				const listening = app.listen(0, "127.0.0.1", () => resolve(listening));
+			});
+
+			const port = (server.address() as AddressInfo).port;
+			const client = new Client({ name: "shutdown-regression", version: "1.0.0" });
+			await client.connect(new SSEClientTransport(new URL(`http://127.0.0.1:${port}/mcp`)));
+
+			// an open sse stream would otherwise hold the listener open forever
+			await closeHttpServer(server, close);
+
+			expect(server.listening).toBe(false);
+			await expect(fetch(`http://127.0.0.1:${port}/mcp`, { headers: { accept: "text/event-stream" } })).rejects.toThrow();
+
+			await client.close();
 		});
 	});
 

--- a/test/mcp-http-transport.test.ts
+++ b/test/mcp-http-transport.test.ts
@@ -253,7 +253,8 @@ test.describe("mcp http transport", () => {
 				const stream = await fetch(server.sseUrl, { headers: { accept: "text/event-stream" } });
 				const reader = stream.body!.getReader();
 				const announcement = new TextDecoder().decode((await reader.read()).value);
-				const sessionId = new URL(announcement.split("data: ")[1].trim(), server.url).searchParams.get("sessionId");
+				const endpoint = announcement.match(/^data: (.+)$/m)?.[1];
+				const sessionId = new URL(endpoint!, server.url).searchParams.get("sessionId");
 
 				// the legacy message route awaits the transport; a rejection there
 				// used to be dropped on the floor, leaving the request hanging
@@ -577,7 +578,8 @@ test.describe("mcp http transport", () => {
 				const stream = await fetch(server.sseUrl, { headers: { accept: "text/event-stream" } });
 				const reader = stream.body!.getReader();
 				const announcement = new TextDecoder().decode((await reader.read()).value);
-				const sessionId = new URL(announcement.split("data: ")[1].trim(), server.url).searchParams.get("sessionId");
+				const endpoint = announcement.match(/^data: (.+)$/m)?.[1];
+				const sessionId = new URL(endpoint!, server.url).searchParams.get("sessionId");
 
 				expect(sessionId).toBeTruthy();
 

--- a/test/mcp-http-transport.test.ts
+++ b/test/mcp-http-transport.test.ts
@@ -672,17 +672,43 @@ test.describe("mcp http transport", () => {
 	});
 
 	test.describe("authorization", () => {
-		test("should accept only the configured bearer token", async () => {
-			const previous = process.env.MOBILEMCP_AUTH;
-			process.env.MOBILEMCP_AUTH = "s3cret-token";
 
-			const { app, close } = createHttpApp();
-			const server = await new Promise<http.Server>(resolve => {
-				const listening = app.listen(0, "127.0.0.1", () => resolve(listening));
-			});
+		/**
+		 * Runs the body with an authenticated server, restoring the environment
+		 * whether or not the app, the listener, or the body itself got that far.
+		 */
+		const withAuthToken = async (token: string, run: (port: number) => Promise<void>): Promise<void> => {
+			const previous = process.env.MOBILEMCP_AUTH;
+			let close: (() => Promise<void>) | undefined;
+			let server: http.Server | undefined;
 
 			try {
-				const port = (server.address() as AddressInfo).port;
+				process.env.MOBILEMCP_AUTH = token;
+
+				const created = createHttpApp();
+				close = created.close;
+				server = await new Promise<http.Server>(resolve => {
+					const listening = created.app.listen(0, "127.0.0.1", () => resolve(listening));
+				});
+
+				await run((server.address() as AddressInfo).port);
+			} finally {
+				if (server !== undefined && close !== undefined) {
+					await closeHttpServer(server, close);
+				} else {
+					await close?.();
+				}
+
+				if (previous === undefined) {
+					delete process.env.MOBILEMCP_AUTH;
+				} else {
+					process.env.MOBILEMCP_AUTH = previous;
+				}
+			}
+		};
+
+		test("should accept only the configured bearer token", async () => {
+			await withAuthToken("s3cret-token", async port => {
 				const get = (headers: Record<string, string>) => fetch(`http://127.0.0.1:${port}/mcp`, {
 					headers: { accept: "text/event-stream", ...headers },
 					redirect: "manual",
@@ -699,27 +725,11 @@ test.describe("mcp http transport", () => {
 				expect(correct.status).toBe(301);
 
 				await Promise.all([missing, wrong, wrongScheme, correct].map(response => response.body?.cancel()));
-			} finally {
-				await closeHttpServer(server, close);
-				if (previous === undefined) {
-					delete process.env.MOBILEMCP_AUTH;
-				} else {
-					process.env.MOBILEMCP_AUTH = previous;
-				}
-			}
+			});
 		});
 
 		test("should guard the sse path and posts too", async () => {
-			const previous = process.env.MOBILEMCP_AUTH;
-			process.env.MOBILEMCP_AUTH = "s3cret-token";
-
-			const { app, close } = createHttpApp();
-			const server = await new Promise<http.Server>(resolve => {
-				const listening = app.listen(0, "127.0.0.1", () => resolve(listening));
-			});
-
-			try {
-				const port = (server.address() as AddressInfo).port;
+			await withAuthToken("s3cret-token", async port => {
 				const sse = await fetch(`http://127.0.0.1:${port}/sse`, { headers: { accept: "text/event-stream" } });
 				const post = await fetch(`http://127.0.0.1:${port}/mcp`, {
 					method: "POST",
@@ -730,14 +740,17 @@ test.describe("mcp http transport", () => {
 				expect(sse.status).toBe(401);
 				expect(post.status).toBe(401);
 				await Promise.all([sse, post].map(response => response.body?.cancel()));
-			} finally {
-				await closeHttpServer(server, close);
-				if (previous === undefined) {
-					delete process.env.MOBILEMCP_AUTH;
-				} else {
-					process.env.MOBILEMCP_AUTH = previous;
-				}
-			}
+			});
+		});
+
+		test("should restore the environment when setup fails", async () => {
+			const previous = process.env.MOBILEMCP_AUTH;
+
+			await expect(withAuthToken("s3cret-token", async () => {
+				throw new Error("body failed");
+			})).rejects.toThrow("body failed");
+
+			expect(process.env.MOBILEMCP_AUTH).toBe(previous);
 		});
 	});
 

--- a/test/mcp-http-transport.test.ts
+++ b/test/mcp-http-transport.test.ts
@@ -336,11 +336,87 @@ test.describe("mcp http transport", () => {
 			}
 		});
 
-		test("should serve a GET carrying our stream marker wherever it arrives", async () => {
+		test("should reconnect a client configured at /mcp after its stream is dropped", async () => {
+			const server = await startServer();
+			const client = new Client({ name: "sse-regression", version: "1.0.0" });
+
+			try {
+				// the endpoint clients were configured with before /sse existed
+				await client.connect(new SSEClientTransport(new URL(server.url)));
+				expect((await client.listTools()).tools.length).toBeGreaterThan(0);
+
+				// forcibly drop the sse response, as a proxy or a network blip would
+				server.server.closeAllConnections();
+
+				// the client re-establishes on its own, even though its reconnect now
+				// reports a protocol version and reaches /mcp rather than /sse
+				expect(await waitUntilUsable(client, 30_000)).toBe(true);
+
+				const result = await client.callTool({ name: "mobile_list_available_devices", arguments: {} }) as any;
+				expect(result.content[0].type).toBe("text");
+			} finally {
+				await client.close();
+				await server.stop();
+			}
+		});
+
+		test("should classify a GET by the cache signature every EventSource sends", async () => {
 			const server = await startServer();
 			try {
-				// a spec-compliant EventSource resumes with the id the stream stamped,
-				// even while reporting a protocol version
+				const get = (headers: Record<string, string>) => fetch(server.url, {
+					headers: { "accept": "text/event-stream", "mcp-protocol-version": LEGACY_PROTOCOL_VERSION, ...headers },
+					redirect: "manual",
+				});
+
+				// what the shipped EventSource sends, and what survives an
+				// intermediary that drops one of the two headers
+				const both = await get({ "cache-control": "no-cache", "pragma": "no-cache" });
+				const cacheControlOnly = await get({ "cache-control": "no-cache" });
+				const pragmaOnly = await get({ pragma: "no-cache" });
+				const noStore = await get({ "cache-control": "no-store" });
+				const listOfDirectives = await get({ "cache-control": "max-age=0, no-cache" });
+
+				// a Streamable HTTP listening GET carries none of them
+				const neither = await get({});
+
+				expect(both.status).toBe(301);
+				expect(cacheControlOnly.status).toBe(301);
+				expect(pragmaOnly.status).toBe(301);
+				expect(noStore.status).toBe(301);
+				expect(listOfDirectives.status).toBe(301);
+				expect(neither.status).toBe(405);
+
+				await Promise.all([both, cacheControlOnly, pragmaOnly, noStore, listOfDirectives, neither]
+					.map(response => response.body?.cancel()));
+			} finally {
+				await server.stop();
+			}
+		});
+
+		test("should not treat an unrelated cache directive as an sse stream", async () => {
+			const server = await startServer();
+			try {
+				const response = await fetch(server.url, {
+					headers: {
+						"accept": "text/event-stream",
+						"mcp-protocol-version": LEGACY_PROTOCOL_VERSION,
+						"cache-control": "max-age=600",
+					},
+					redirect: "manual",
+				});
+
+				expect(response.status).toBe(405);
+				await response.body?.cancel();
+			} finally {
+				await server.stop();
+			}
+		});
+
+		test("should classify a GET carrying our stream marker as sse", async () => {
+			const server = await startServer();
+			try {
+				// a spec-compliant EventSource re-establishes with the id the stream
+				// stamped, even while reporting a protocol version
 				const response = await fetch(server.url, {
 					headers: {
 						"accept": "text/event-stream",
@@ -350,8 +426,8 @@ test.describe("mcp http transport", () => {
 					redirect: "manual",
 				});
 
-				expect(response.status).toBe(200);
-				expect(response.headers.get("content-type")).toContain("text/event-stream");
+				expect(response.status).toBe(301);
+				expect(response.headers.get("location")).toBe("/sse");
 				await response.body?.cancel();
 			} finally {
 				await server.stop();
@@ -482,6 +558,16 @@ test.describe("mcp http transport", () => {
 				const sseTools = await sseClient.listTools();
 				expect(streamableTools.tools.length).toBeGreaterThan(0);
 				expect(sseTools.tools.length).toBe(streamableTools.tools.length);
+
+				// the streamable client holds no stream: all remaining slots are free
+				const streams: Response[] = [];
+				for (let index = 0; index < 7; index++) {
+					const stream = await fetch(server.sseUrl, { headers: { accept: "text/event-stream" } });
+					expect(stream.status).toBe(200);
+					streams.push(stream);
+				}
+
+				await Promise.all(streams.map(stream => stream.body?.cancel()));
 			} finally {
 				await sseClient.close();
 				await streamableClient.close();

--- a/test/mcp-http-transport.test.ts
+++ b/test/mcp-http-transport.test.ts
@@ -4,13 +4,14 @@ import type { AddressInfo } from "node:net";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import {
 	CLIENT_CAPABILITIES_META_KEY,
 	CLIENT_INFO_META_KEY,
 	PROTOCOL_VERSION_META_KEY,
 } from "@modelcontextprotocol/server";
 
-import { createHttpApp, closeHttpServer } from "../src/http-server";
+import { createHttpApp, closeHttpServer, createShutdownHandler, listenHttpServer } from "../src/http-server";
 import { Mobilecli } from "../src/mobilecli";
 
 process.env.MOBILEMCP_DISABLE_TELEMETRY = "1";
@@ -105,6 +106,12 @@ test.describe("mcp http transport", () => {
 				let bytesWritten = 0;
 
 				const status = await new Promise<number>((resolve, reject) => {
+					const timer = setTimeout(() => reject(new Error("no response to the oversized request")), 10_000);
+					const settle = (outcome: () => void) => {
+						clearTimeout(timer);
+						outcome();
+					};
+
 					request = http.request({
 						host: "127.0.0.1",
 						port: server.port,
@@ -118,22 +125,20 @@ test.describe("mcp http transport", () => {
 
 					request.on("response", response => {
 						response.resume();
-						resolve(response.statusCode ?? 0);
+						settle(() => resolve(response.statusCode ?? 0));
 					});
 
 					// the socket is torn down once the request is refused, which must
 					// not fail the test
 					request.on("error", error => {
 						if (bytesWritten === 0) {
-							reject(error);
+							settle(() => reject(error));
 						}
 					});
 
 					const chunk = "x".repeat(1024);
 					request.write(chunk);
 					bytesWritten += chunk.length;
-
-					setTimeout(() => reject(new Error("no response to the oversized request")), 10_000);
 				});
 
 				// the declared length is refused up front, so the body is never read:
@@ -236,6 +241,40 @@ test.describe("mcp http transport", () => {
 				const body = await response.json() as any;
 				expect(body.error.code).toBe(-32700);
 			} finally {
+				await server.stop();
+			}
+		});
+
+		test("should forward a rejecting route handler as an internal error", async () => {
+			const server = await startServer();
+			const originalHandlePostMessage = SSEServerTransport.prototype.handlePostMessage;
+
+			try {
+				const stream = await fetch(server.sseUrl, { headers: { accept: "text/event-stream" } });
+				const reader = stream.body!.getReader();
+				const announcement = new TextDecoder().decode((await reader.read()).value);
+				const sessionId = new URL(announcement.split("data: ")[1].trim(), server.url).searchParams.get("sessionId");
+
+				// the legacy message route awaits the transport; a rejection there
+				// used to be dropped on the floor, leaving the request hanging
+				SSEServerTransport.prototype.handlePostMessage = async function handlePostMessage() {
+					throw new Error("transport exploded");
+				};
+
+				const response = await fetch(`${server.url}?sessionId=${sessionId}`, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+				});
+
+				expect(response.status).toBe(500);
+				const body = await response.json() as any;
+				expect(body.error.code).toBe(-32603);
+				expect(body.error.message).toBe("Internal error");
+
+				await reader.cancel();
+			} finally {
+				SSEServerTransport.prototype.handlePostMessage = originalHandlePostMessage;
 				await server.stop();
 			}
 		});
@@ -356,6 +395,35 @@ test.describe("mcp http transport", () => {
 				expect(result.content[0].type).toBe("text");
 			} finally {
 				await client.close();
+				await server.stop();
+			}
+		});
+
+		test("should close a stream whose connect fails after the response was announced", async () => {
+			const server = await startServer();
+			const originalStart = SSEServerTransport.prototype.start;
+
+			// fail once the head and the endpoint event are already on the wire, so
+			// the failure cannot be reported as a status code
+			SSEServerTransport.prototype.start = async function start() {
+				await originalStart.call(this);
+				throw new Error("connect failed after headers");
+			};
+
+			try {
+				const response = await fetch(server.sseUrl, { headers: { accept: "text/event-stream" } });
+				expect(response.status).toBe(200);
+
+				// the response is ended rather than left open forever
+				await response.text();
+
+				// and the slot it held was released
+				SSEServerTransport.prototype.start = originalStart;
+				const healthy = await fetch(server.sseUrl, { headers: { accept: "text/event-stream" } });
+				expect(healthy.status).toBe(200);
+				await healthy.body?.cancel();
+			} finally {
+				SSEServerTransport.prototype.start = originalStart;
 				await server.stop();
 			}
 		});
@@ -603,6 +671,76 @@ test.describe("mcp http transport", () => {
 		});
 	});
 
+	test.describe("authorization", () => {
+		test("should accept only the configured bearer token", async () => {
+			const previous = process.env.MOBILEMCP_AUTH;
+			process.env.MOBILEMCP_AUTH = "s3cret-token";
+
+			const { app, close } = createHttpApp();
+			const server = await new Promise<http.Server>(resolve => {
+				const listening = app.listen(0, "127.0.0.1", () => resolve(listening));
+			});
+
+			try {
+				const port = (server.address() as AddressInfo).port;
+				const get = (headers: Record<string, string>) => fetch(`http://127.0.0.1:${port}/mcp`, {
+					headers: { accept: "text/event-stream", ...headers },
+					redirect: "manual",
+				});
+
+				const missing = await get({});
+				const wrong = await get({ authorization: "Bearer wrong-token" });
+				const wrongScheme = await get({ authorization: "s3cret-token" });
+				const correct = await get({ authorization: "Bearer s3cret-token" });
+
+				expect(missing.status).toBe(401);
+				expect(wrong.status).toBe(401);
+				expect(wrongScheme.status).toBe(401);
+				expect(correct.status).toBe(301);
+
+				await Promise.all([missing, wrong, wrongScheme, correct].map(response => response.body?.cancel()));
+			} finally {
+				await closeHttpServer(server, close);
+				if (previous === undefined) {
+					delete process.env.MOBILEMCP_AUTH;
+				} else {
+					process.env.MOBILEMCP_AUTH = previous;
+				}
+			}
+		});
+
+		test("should guard the sse path and posts too", async () => {
+			const previous = process.env.MOBILEMCP_AUTH;
+			process.env.MOBILEMCP_AUTH = "s3cret-token";
+
+			const { app, close } = createHttpApp();
+			const server = await new Promise<http.Server>(resolve => {
+				const listening = app.listen(0, "127.0.0.1", () => resolve(listening));
+			});
+
+			try {
+				const port = (server.address() as AddressInfo).port;
+				const sse = await fetch(`http://127.0.0.1:${port}/sse`, { headers: { accept: "text/event-stream" } });
+				const post = await fetch(`http://127.0.0.1:${port}/mcp`, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+				});
+
+				expect(sse.status).toBe(401);
+				expect(post.status).toBe(401);
+				await Promise.all([sse, post].map(response => response.body?.cancel()));
+			} finally {
+				await closeHttpServer(server, close);
+				if (previous === undefined) {
+					delete process.env.MOBILEMCP_AUTH;
+				} else {
+					process.env.MOBILEMCP_AUTH = previous;
+				}
+			}
+		});
+	});
+
 	test.describe("shutdown", () => {
 		test("should release the handler and an open sse stream", async () => {
 			const { app, close } = createHttpApp();
@@ -612,15 +750,85 @@ test.describe("mcp http transport", () => {
 
 			const port = (server.address() as AddressInfo).port;
 			const client = new Client({ name: "shutdown-regression", version: "1.0.0" });
-			await client.connect(new SSEClientTransport(new URL(`http://127.0.0.1:${port}/sse`)));
 
-			// an open sse stream would otherwise hold the listener open forever
-			await closeHttpServer(server, close);
+			try {
+				await client.connect(new SSEClientTransport(new URL(`http://127.0.0.1:${port}/sse`)));
 
-			expect(server.listening).toBe(false);
-			await expect(fetch(`http://127.0.0.1:${port}/mcp`, { headers: { accept: "text/event-stream" } })).rejects.toThrow();
+				// an open sse stream would otherwise hold the listener open forever
+				await closeHttpServer(server, close);
 
-			await client.close();
+				expect(server.listening).toBe(false);
+				await expect(fetch(`http://127.0.0.1:${port}/mcp`, { headers: { accept: "text/event-stream" } })).rejects.toThrow();
+			} finally {
+				await client.close();
+				await closeHttpServer(server, close);
+			}
+		});
+
+		test("should run the shutdown sequence once however many signals arrive", async () => {
+			const { app } = createHttpApp();
+			const server = await new Promise<http.Server>(resolve => {
+				const listening = app.listen(0, "127.0.0.1", () => resolve(listening));
+			});
+
+			try {
+				let closeCalls = 0;
+				let settledCalls = 0;
+				const shutdown = createShutdownHandler(server, async () => {
+					closeCalls++;
+				}, () => {
+					settledCalls++;
+				});
+
+				shutdown();
+				shutdown();
+				shutdown();
+
+				await expect.poll(() => settledCalls, { timeout: 5000 }).toBe(1);
+				expect(closeCalls).toBe(1);
+			} finally {
+				server.closeAllConnections();
+				await new Promise<void>(resolve => server.close(() => resolve()));
+			}
+		});
+
+		test("should give up waiting on a resource that never closes", async () => {
+			const { app } = createHttpApp();
+			const server = await new Promise<http.Server>(resolve => {
+				const listening = app.listen(0, "127.0.0.1", () => resolve(listening));
+			});
+
+			try {
+				const startedAt = Date.now();
+				await closeHttpServer(server, () => new Promise<void>(() => {}), 250);
+
+				expect(Date.now() - startedAt).toBeLessThan(5_000);
+			} finally {
+				server.closeAllConnections();
+				await new Promise<void>(resolve => server.close(() => resolve()));
+			}
+		});
+
+		test("should report a bind failure instead of throwing it", async () => {
+			const first = createHttpApp();
+			const firstServer = await new Promise<http.Server>(resolve => {
+				const listening = first.app.listen(0, "127.0.0.1", () => resolve(listening));
+			});
+
+			const port = (firstServer.address() as AddressInfo).port;
+			const second = createHttpApp();
+			let secondServer: http.Server | undefined;
+
+			try {
+				const bindError = await new Promise<NodeJS.ErrnoException>(resolve => {
+					secondServer = listenHttpServer(second.app, "127.0.0.1", port, () => {}, resolve);
+				});
+
+				expect(bindError.code).toBe("EADDRINUSE");
+			} finally {
+				secondServer?.close();
+				await closeHttpServer(firstServer, first.close);
+			}
 		});
 	});
 
@@ -656,8 +864,9 @@ test.describe("mcp http transport", () => {
 			}) as typeof fetch;
 			delete process.env.MOBILEMCP_DISABLE_TELEMETRY;
 
-			const server = await startServer();
+			let server: RunningServer | undefined;
 			try {
+				server = await startServer();
 				await fetch(server.url, {
 					method: "POST",
 					headers: {
@@ -687,7 +896,7 @@ test.describe("mcp http transport", () => {
 				expect(robotEvent.properties.ProtocolVersion).toBe(MODERN_PROTOCOL_VERSION);
 				expect(robotEvent.properties.ProtocolEra).toBe("modern");
 			} finally {
-				await server.stop();
+				await server?.stop();
 				process.env.MOBILEMCP_DISABLE_TELEMETRY = "1";
 				globalThis.fetch = originalFetch;
 				Mobilecli.prototype.getVersion = originalGetVersion;

--- a/test/mcp-protocol.test.ts
+++ b/test/mcp-protocol.test.ts
@@ -1,0 +1,381 @@
+import { test, expect } from "@playwright/test";
+import {
+	createMcpHandler,
+	InMemoryTransport,
+	CLIENT_CAPABILITIES_META_KEY,
+	CLIENT_INFO_META_KEY,
+	PROTOCOL_VERSION_META_KEY,
+} from "@modelcontextprotocol/server";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
+
+import {
+	createMcpServer,
+	clientNameFromRequestMeta,
+	protocolVersionFromRequestMeta,
+} from "../src/server";
+
+// telemetry is off by default in these tests; the one telemetry test enables it
+// explicitly and stubs global fetch.
+process.env.MOBILEMCP_DISABLE_TELEMETRY = "1";
+
+const MODERN_PROTOCOL_VERSION = "2026-07-28";
+const LEGACY_PROTOCOL_VERSION = "2025-06-18";
+
+const modernEnvelope = (clientName: string = "mobile-mcp-tests") => ({
+	[PROTOCOL_VERSION_META_KEY]: MODERN_PROTOCOL_VERSION,
+	[CLIENT_INFO_META_KEY]: { name: clientName, version: "1.2.3" },
+	[CLIENT_CAPABILITIES_META_KEY]: {},
+});
+
+interface HttpResponse {
+	status: number;
+	sessionId: string | null;
+	body: any;
+}
+
+const newHandler = () => createMcpHandler(createMcpServer, { legacy: "stateless" });
+
+const readBody = async (response: Response): Promise<any> => {
+	const text = await response.text();
+	if (response.headers.get("content-type")?.includes("text/event-stream")) {
+		const line = text.split("\n").find(candidate => candidate.startsWith("data: "));
+		return line ? JSON.parse(line.substring("data: ".length)) : undefined;
+	}
+
+	return text.length > 0 ? JSON.parse(text) : undefined;
+};
+
+const post = async (handler: ReturnType<typeof newHandler>, body: unknown, headers: Record<string, string> = {}): Promise<HttpResponse> => {
+	const response = await handler.fetch(new Request("http://localhost/mcp", {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			"accept": "application/json, text/event-stream",
+			...headers,
+		},
+		body: JSON.stringify(body),
+	}));
+
+	return {
+		status: response.status,
+		sessionId: response.headers.get("mcp-session-id"),
+		body: await readBody(response),
+	};
+};
+
+const modernRequest = (id: number, method: string, params: Record<string, unknown> = {}, clientName?: string) => ({
+	jsonrpc: "2.0",
+	id,
+	method,
+	params: { ...params, _meta: modernEnvelope(clientName) },
+});
+
+const modernHeaders = (method: string, name?: string): Record<string, string> => {
+	const headers: Record<string, string> = {
+		"MCP-Protocol-Version": MODERN_PROTOCOL_VERSION,
+		"Mcp-Method": method,
+	};
+
+	if (name !== undefined) {
+		headers["Mcp-Name"] = name;
+	}
+
+	return headers;
+};
+
+test.describe("mcp protocol 2026-07-28", () => {
+
+	test.describe("discovery", () => {
+		test("should answer server/discover with the modern revision and capabilities", async () => {
+			const handler = newHandler();
+			try {
+				const response = await post(handler, modernRequest(1, "server/discover"), modernHeaders("server/discover"));
+
+				expect(response.status).toBe(200);
+				expect(response.body.result.supportedVersions).toEqual([MODERN_PROTOCOL_VERSION]);
+				expect(response.body.result.capabilities.tools).toBeDefined();
+				expect(response.body.result._meta["io.modelcontextprotocol/serverInfo"]).toEqual({
+					name: "mobile-mcp",
+					version: expect.any(String),
+				});
+			} finally {
+				await handler.close();
+			}
+		});
+
+		test("should return cacheable server/discover results", async () => {
+			const handler = newHandler();
+			try {
+				const response = await post(handler, modernRequest(1, "server/discover"), modernHeaders("server/discover"));
+
+				expect(response.body.result.resultType).toBe("complete");
+				expect(response.body.result.ttlMs).toBe(300_000);
+				expect(response.body.result.cacheScope).toBe("public");
+			} finally {
+				await handler.close();
+			}
+		});
+	});
+
+	test.describe("modern requests", () => {
+		test("should serve tools/list directly, without an initialize handshake", async () => {
+			const handler = newHandler();
+			try {
+				const response = await post(handler, modernRequest(1, "tools/list"), modernHeaders("tools/list"));
+
+				expect(response.status).toBe(200);
+				const toolNames = response.body.result.tools.map((tool: any) => tool.name);
+				expect(toolNames).toContain("mobile_list_available_devices");
+				expect(toolNames).toContain("mobile_take_screenshot");
+			} finally {
+				await handler.close();
+			}
+		});
+
+		test("should mark list results as cacheable", async () => {
+			const handler = newHandler();
+			try {
+				const response = await post(handler, modernRequest(1, "tools/list"), modernHeaders("tools/list"));
+
+				expect(response.body.result.resultType).toBe("complete");
+				expect(response.body.result.ttlMs).toBe(300_000);
+				expect(response.body.result.cacheScope).toBe("public");
+			} finally {
+				await handler.close();
+			}
+		});
+
+		test("should reject initialize on the modern era", async () => {
+			const handler = newHandler();
+			try {
+				const response = await post(handler, modernRequest(1, "initialize"), modernHeaders("initialize"));
+
+				expect(response.body.error.code).toBe(-32601);
+			} finally {
+				await handler.close();
+			}
+		});
+
+		test("should be stateless — no session id is ever issued or required", async () => {
+			const handler = newHandler();
+			try {
+				const first = await post(handler, modernRequest(1, "tools/list"), modernHeaders("tools/list"));
+				const second = await post(handler, modernRequest(2, "server/discover"), modernHeaders("server/discover"));
+
+				expect(first.sessionId).toBeNull();
+				expect(second.sessionId).toBeNull();
+				expect(first.body.result.tools.length).toBeGreaterThan(0);
+				expect(second.body.result.supportedVersions).toEqual([MODERN_PROTOCOL_VERSION]);
+			} finally {
+				await handler.close();
+			}
+		});
+
+		test("should answer session operations with method not allowed", async () => {
+			const handler = newHandler();
+			try {
+				const get = await handler.fetch(new Request("http://localhost/mcp", { method: "GET", headers: { accept: "text/event-stream" } }));
+				const del = await handler.fetch(new Request("http://localhost/mcp", { method: "DELETE" }));
+
+				expect(get.status).toBe(405);
+				expect(del.status).toBe(405);
+			} finally {
+				await handler.close();
+			}
+		});
+	});
+
+	test.describe("http header rules", () => {
+		test("should reject a modern request without the Mcp-Method header", async () => {
+			const handler = newHandler();
+			try {
+				const response = await post(handler, modernRequest(1, "tools/list"), {
+					"MCP-Protocol-Version": MODERN_PROTOCOL_VERSION,
+				});
+
+				expect(response.status).toBe(400);
+				expect(response.body.error.code).toBe(-32020);
+			} finally {
+				await handler.close();
+			}
+		});
+
+		test("should reject a tools/call whose Mcp-Name disagrees with the body", async () => {
+			const handler = newHandler();
+			try {
+				const request = modernRequest(1, "tools/call", { name: "mobile_list_available_devices", arguments: {} });
+				const response = await post(handler, request, modernHeaders("tools/call", "mobile_take_screenshot"));
+
+				expect(response.status).toBe(400);
+				expect(response.body.error.code).toBe(-32020);
+			} finally {
+				await handler.close();
+			}
+		});
+
+		test("should reject a protocol version header that disagrees with the envelope", async () => {
+			const handler = newHandler();
+			try {
+				const response = await post(handler, modernRequest(1, "tools/list"), {
+					"MCP-Protocol-Version": LEGACY_PROTOCOL_VERSION,
+					"Mcp-Method": "tools/list",
+				});
+
+				expect(response.status).toBe(400);
+				expect(response.body.error.code).toBe(-32020);
+			} finally {
+				await handler.close();
+			}
+		});
+
+		test("should reject a modern request that carries no _meta envelope", async () => {
+			const handler = newHandler();
+			try {
+				const response = await post(handler, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }, modernHeaders("tools/list"));
+
+				expect(response.status).toBe(400);
+				expect(response.body.error.code).toBe(-32602);
+			} finally {
+				await handler.close();
+			}
+		});
+	});
+
+	test.describe("stdio transport", () => {
+		test("should serve modern requests over stdio without an initialize handshake", async () => {
+			const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+			const stdio = serveStdio(createMcpServer, { transport: serverTransport });
+
+			try {
+				const messages: any[] = [];
+				clientTransport.onmessage = message => {
+					messages.push(message);
+				};
+
+				await clientTransport.start();
+				await clientTransport.send(modernRequest(1, "server/discover") as any);
+				await expect.poll(() => messages.length, { timeout: 5000 }).toBe(1);
+
+				expect(messages[0].result.supportedVersions).toEqual([MODERN_PROTOCOL_VERSION]);
+				expect(messages[0].result.resultType).toBe("complete");
+			} finally {
+				await stdio.close();
+			}
+		});
+
+		test("should still serve the 2025-era handshake over stdio", async () => {
+			const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+			const stdio = serveStdio(createMcpServer, { transport: serverTransport });
+
+			try {
+				const messages: any[] = [];
+				clientTransport.onmessage = message => {
+					messages.push(message);
+				};
+
+				await clientTransport.start();
+				await clientTransport.send({
+					jsonrpc: "2.0",
+					id: 1,
+					method: "initialize",
+					params: {
+						protocolVersion: LEGACY_PROTOCOL_VERSION,
+						capabilities: {},
+						clientInfo: { name: "legacy-client", version: "0.1.0" },
+					},
+				} as any);
+				await expect.poll(() => messages.length, { timeout: 5000 }).toBe(1);
+
+				expect(messages[0].result.protocolVersion).toBe(LEGACY_PROTOCOL_VERSION);
+				expect(messages[0].result.resultType).toBeUndefined();
+			} finally {
+				await stdio.close();
+			}
+		});
+	});
+
+	test.describe("telemetry", () => {
+		test("should read the client identity from per-request metadata", () => {
+			const envelope = modernEnvelope("cursor");
+
+			expect(clientNameFromRequestMeta(envelope)).toBe("cursor");
+			expect(protocolVersionFromRequestMeta(envelope)).toBe(MODERN_PROTOCOL_VERSION);
+		});
+
+		test("should ignore a malformed or absent client identity", () => {
+			expect(clientNameFromRequestMeta(undefined)).toBeUndefined();
+			expect(clientNameFromRequestMeta({})).toBeUndefined();
+			expect(clientNameFromRequestMeta({ [CLIENT_INFO_META_KEY]: "cursor" })).toBeUndefined();
+			expect(clientNameFromRequestMeta({ [CLIENT_INFO_META_KEY]: { name: "" } })).toBeUndefined();
+			expect(protocolVersionFromRequestMeta({ [PROTOCOL_VERSION_META_KEY]: 42 })).toBeUndefined();
+		});
+
+		test("should report the requesting client from _meta, not from initialize", async () => {
+			const events: any[] = [];
+			const originalFetch = globalThis.fetch;
+
+			globalThis.fetch = (async (input: any, init: any) => {
+				events.push(JSON.parse(init.body));
+				return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+			}) as typeof fetch;
+			delete process.env.MOBILEMCP_DISABLE_TELEMETRY;
+
+			const handler = newHandler();
+			try {
+				const request = modernRequest(1, "tools/call", { name: "mobile_list_available_devices", arguments: {} }, "claude-code");
+				await post(handler, request, modernHeaders("tools/call", "mobile_list_available_devices"));
+
+				await expect.poll(() => events.filter(event => event.properties.ToolName === "mobile_list_available_devices").length, { timeout: 5000 }).toBeGreaterThan(0);
+
+				const toolEvent = events.find(event => event.properties.ToolName === "mobile_list_available_devices");
+				expect(toolEvent.properties.AgentName).toBe("claude-code");
+				expect(toolEvent.properties.ProtocolVersion).toBe(MODERN_PROTOCOL_VERSION);
+				expect(toolEvent.properties.ProtocolEra).toBe("modern");
+			} finally {
+				await handler.close();
+				process.env.MOBILEMCP_DISABLE_TELEMETRY = "1";
+				globalThis.fetch = originalFetch;
+			}
+		});
+	});
+
+	test.describe("legacy interoperability", () => {
+		test("should still answer the 2025-era initialize handshake", async () => {
+			const handler = newHandler();
+			try {
+				const response = await post(handler, {
+					jsonrpc: "2.0",
+					id: 1,
+					method: "initialize",
+					params: {
+						protocolVersion: LEGACY_PROTOCOL_VERSION,
+						capabilities: {},
+						clientInfo: { name: "legacy-client", version: "0.1.0" },
+					},
+				});
+
+				expect(response.status).toBe(200);
+				expect(response.body.result.protocolVersion).toBe(LEGACY_PROTOCOL_VERSION);
+				expect(response.body.result.serverInfo.name).toBe("mobile-mcp");
+				expect(response.sessionId).toBeNull();
+			} finally {
+				await handler.close();
+			}
+		});
+
+		test("should serve legacy tools/list without modern-only result fields", async () => {
+			const handler = newHandler();
+			try {
+				const response = await post(handler, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+
+				expect(response.status).toBe(200);
+				expect(response.body.result.tools.length).toBeGreaterThan(0);
+				expect(response.body.result.resultType).toBeUndefined();
+				expect(response.body.result.ttlMs).toBeUndefined();
+				expect(response.body.result.cacheScope).toBeUndefined();
+			} finally {
+				await handler.close();
+			}
+		});
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,9 @@
     "target": "ESNext",
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "strict": true,
-    "module": "CommonJS",
+    "module": "node16",
     "outDir": "./lib"
   },
   "include": [


### PR DESCRIPTION
## Summary

- migrate the MCP server from `@modelcontextprotocol/sdk` v1 to the split TypeScript SDK v2 packages
- support the [July 28, 2026 MCP specification](https://modelcontextprotocol.io/specification/2026-07-28) through stateless Streamable HTTP and dual-era stdio serving
- add `server/discover`, per-request protocol/client metadata, required result and cache fields, and modern HTTP header validation
- preserve initialization-based Streamable HTTP clients and the deprecated HTTP+SSE transport
- keep existing `/mcp` SSE configurations working, add `/sse` as the canonical SSE endpoint, cap request bodies at 4 MB, and preserve telemetry attribution

The HTTP+SSE compatibility path is isolated from the modern stateless handler. Existing `/mcp` clients are redirected to `/sse`; the compatibility classifier also recognizes reconnect requests from the currently supported SDK v1 EventSource stack.

## Test plan

- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm audit --audit-level high --omit dev`
- Playwright MCP protocol, HTTP transport, utility, PNG, and mobilecli suites (69 tests)
- compiled-server smoke tests for modern Streamable HTTP, legacy Streamable HTTP, HTTP+SSE reconnects, authentication, body limits, and shutdown

Device-specific suites remain dependent on attached simulators, emulators, or physical devices.
