### PR TITLE
fix: flatten element tree in MobileDevice.getElementsOnScreen

### DIFF
--- a/src/mobile-device.ts
+++ b/src/mobile-device.ts
@@ -43,6 +43,7 @@ interface UIElementResponse {
 		height: number;
 	};
 	focused?: boolean;
+	children?: UIElementResponse[];
 }
 
 interface DumpUIResponse {
@@ -196,9 +197,23 @@ export class MobileDevice implements Robot {
 		this.runCommand(["io", "longpress", `${x},${y}`, "--duration", `${duration}`]);
 	}
 
+	private collectElements(elements: UIElementResponse[]): UIElementResponse[] {
+		const collected: UIElementResponse[] = [];
+		for (const element of elements) {
+			collected.push(element);
+			if (element.children) {
+				collected.push(...this.collectElements(element.children));
+			}
+		}
+
+		return collected;
+	}
+
 	public async getElementsOnScreen(): Promise<ScreenElement[]> {
 		const response = JSON.parse(this.runCommand(["dump", "ui"])) as DumpUIResponse;
-		return response.data.elements.map(element => ({
+
+		// "dump ui" returns a tree; flatten it so nested elements are not lost
+		return this.collectElements(response.data.elements).map(element => ({
 			type: element.type,
 			label: element.label,
 			text: element.text,

--- a/test/mobile-device.test.ts
+++ b/test/mobile-device.test.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+
+import { MobileDevice } from "../src/mobile-device";
+
+function createMockMobileDevice(mockResponse: string): { device: MobileDevice; calls: string[][] } {
+	const device = new MobileDevice("test-device");
+	const calls: string[][] = [];
+
+	(device as any).mobilecli.executeCommand = function(args: string[]): string {
+		calls.push(args);
+		return mockResponse;
+	};
+
+	return { device, calls };
+}
+
+test.describe("MobileDevice", () => {
+
+	test.describe("getElementsOnScreen", () => {
+
+		const rect = { x: 0, y: 0, width: 100, height: 50 };
+
+		test("should flatten the element tree returned by dump ui", async () => {
+			const mockResponse = JSON.stringify({
+				status: "ok",
+				data: {
+					elements: [
+						{
+							type: "Window",
+							rect: { x: 0, y: 0, width: 400, height: 800 },
+							children: [
+								{
+									type: "Button",
+									text: "OK",
+									rect,
+									children: [
+										{ type: "StaticText", text: "OK", rect },
+									],
+								},
+								{ type: "TextField", value: "hello", rect, focused: true },
+							],
+						},
+					],
+				},
+			});
+
+			const { device, calls } = createMockMobileDevice(mockResponse);
+			const elements = await device.getElementsOnScreen();
+
+			expect(calls.length).toBe(1);
+			expect(calls[0]).toEqual(["dump", "ui", "--device", "test-device"]);
+
+			expect(elements.length).toBe(4);
+			expect(elements.map(e => e.type)).toEqual(["Window", "Button", "StaticText", "TextField"]);
+			expect(elements[3].value).toBe("hello");
+			expect(elements[3].focused).toBe(true);
+		});
+
+		test("should keep working for elements without children", async () => {
+			const mockResponse = JSON.stringify({
+				status: "ok",
+				data: {
+					elements: [
+						{ type: "Button", text: "OK", rect },
+						{ type: "Button", text: "Cancel", rect },
+					],
+				},
+			});
+
+			const { device } = createMockMobileDevice(mockResponse);
+			const elements = await device.getElementsOnScreen();
+
+			expect(elements.length).toBe(2);
+			expect(elements.map(e => e.text)).toEqual(["OK", "Cancel"]);
+		});
+	});
+});


### PR DESCRIPTION
## Problem

`mobile_list_elements_on_screen` returns only a single root element when the
device goes through the mobilecli path (`MobileDevice`), making the tool
unusable for finding tap targets — every nested element is lost.

## Root cause

`mobilecli dump ui` returns a **tree** (each element carries a `children`
`UIElementResponse` interface didn't even declare the `children` field, so
the subtree was silently dropped.

The older uiautomator path (`android.ts`) flattens the hierarchy recursively
via `collectElements`, so a flat list is clearly the intended contract of
`getElementsOnScreen()` — this is a regression in the mobilecli path.

## Fix

- Declare the missing `children?: UIElementResponse[]` field
- Recursively flatten the tree before mapping (same `collectElements`
  approach as `android.ts`)

## Verification

- Unit tests added (`test/mobile-device.test.ts`, mocking `executeCommand`
  like the existing `mobilecli.test.ts`): nested tree of 4 elements is fully
  flattened; flat responses keep working unchanged
- On a real Android emulator (Settings app): **before** 1 element (root
  only) → **after** 73 elements with text/coordinates
- End-to-end flow works: `list elements → tap "Network & internet" by its
  rect center → list again` confirms navigation to the subpage