### PR TITLE
fix: round coordinates before passing them to mobilecli

### DIFF
--- a/src/mobile-device.ts
+++ b/src/mobile-device.ts
@@ -133,7 +133,7 @@ export class MobileDevice implements Robot {
 				break;
 		}
 
-		this.runCommand(["io", "swipe", `${x},${y},${endX},${endY}`]);
+		this.runCommand(["io", "swipe", `${Math.round(x)},${Math.round(y)},${Math.round(endX)},${Math.round(endY)}`]);
 	}
 
 	public async getScreenshot(): Promise<Buffer> {
@@ -183,7 +183,8 @@ export class MobileDevice implements Robot {
 	}
 
 	public async tap(x: number, y: number): Promise<void> {
-		this.runCommand(["io", "tap", `${x},${y}`]);
+		// mobilecli rejects fractional coordinates ("x and y must be integers")
+		this.runCommand(["io", "tap", `${Math.round(x)},${Math.round(y)}`]);
 	}
 
 	public async doubleTap(x: number, y: number): Promise<void> {
@@ -193,7 +194,7 @@ export class MobileDevice implements Robot {
 	}
 
 	public async longPress(x: number, y: number, duration: number): Promise<void> {
-		this.runCommand(["io", "longpress", `${x},${y}`, "--duration", `${duration}`]);
+		this.runCommand(["io", "longpress", `${Math.round(x)},${Math.round(y)}`, "--duration", `${duration}`]);
 	}
 
 	public async getElementsOnScreen(): Promise<ScreenElement[]> {

--- a/test/mobile-device.test.ts
+++ b/test/mobile-device.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+import { MobileDevice } from "../src/mobile-device";
+
+function createMockMobileDevice(mockResponse: string): { device: MobileDevice; calls: string[][] } {
+	const device = new MobileDevice("test-device");
+	const calls: string[][] = [];
+
+	(device as any).mobilecli.executeCommand = function(args: string[]): string {
+		calls.push(args);
+		return mockResponse;
+	};
+
+	return { device, calls };
+}
+
+test.describe("MobileDevice", () => {
+
+	test.describe("coordinate rounding", () => {
+
+		test("tap should round fractional coordinates before calling mobilecli", async () => {
+			const { device, calls } = createMockMobileDevice("");
+			await device.tap(450, 784.5);
+
+			expect(calls.length).toBe(1);
+			expect(calls[0]).toEqual(["io", "tap", "450,785", "--device", "test-device"]);
+		});
+
+		test("longPress should round fractional coordinates before calling mobilecli", async () => {
+			const { device, calls } = createMockMobileDevice("");
+			await device.longPress(100.4, 200.6, 500);
+
+			expect(calls.length).toBe(1);
+			expect(calls[0]).toEqual(["io", "longpress", "100,201", "--duration", "500", "--device", "test-device"]);
+		});
+
+		test("swipeFromCoordinate should round fractional coordinates before calling mobilecli", async () => {
+			const { device, calls } = createMockMobileDevice("");
+			await device.swipeFromCoordinate(100.5, 300.2, "up", 400);
+
+			expect(calls.length).toBe(1);
+			expect(calls[0]).toEqual(["io", "swipe", "101,300,101,-100", "--device", "test-device"]);
+		});
+
+		test("tap should keep integer coordinates unchanged", async () => {
+			const { device, calls } = createMockMobileDevice("");
+			await device.tap(450, 785);
+
+			expect(calls[0]).toEqual(["io", "tap", "450,785", "--device", "test-device"]);
+		});
+	});
+});


### PR DESCRIPTION
## Problem

`mobile_click_on_screen_at_coordinates` (and long-press / swipe-from-
coordinate) fails whenever the coordinates are fractional:

    invalid coordinate values. x and y must be integers. Got x='450', y='784.5'

The tool schema is `z.coerce.number()`, and computing a tap target from an
element's rect center (`x + width / 2`) naturally produces `.5` values
whenever the element size is odd — so this is easy to hit in normal use of
`mobile_list_elements_on_screen` output.

## Root cause

`MobileDevice.tap` / `longPress` / `swipeFromCoordinate` interpolate the
incoming numbers into the mobilecli command as-is, and the mobilecli binary
rejects non-integers.

## Fix

Round the coordinates at the mobilecli boundary (`Math.round`). `doubleTap`
goes through `tap`, so it is covered too.

## Verification

- Unit tests added: fractional coordinates are rounded for all three
  methods; integer coordinates pass through unchanged
- Reproduced on a real Android emulator: `tap(450, 784.5)` failed with the
  error above before the fix and taps correctly after