### PR TITLE
fix(android): recurse into mobilecli children when listing UI elements

### DIFF
--- a/src/mobile-device.ts
+++ b/src/mobile-device.ts
@@ -43,6 +43,7 @@ interface UIElementResponse {
 		height: number;
 	};
 	focused?: boolean;
+	children?: UIElementResponse[];
 }
 
 interface DumpUIResponse {
@@ -58,6 +59,25 @@ interface OrientationResponse {
 		orientation: Orientation;
 	};
 }
+
+const flattenUIElement = (element: UIElementResponse): ScreenElement[] => {
+	const screenElement: ScreenElement = {
+		type: element.type,
+		label: element.label,
+		text: element.text,
+		name: element.name,
+		value: element.value,
+		identifier: element.identifier,
+		rect: element.rect,
+		focused: element.focused,
+	};
+
+	if (!element.children) {
+		return [screenElement];
+	}
+
+	return [screenElement, ...element.children.flatMap(child => flattenUIElement(child))];
+};
 
 export class MobileDevice implements Robot {
 
@@ -198,16 +218,7 @@ export class MobileDevice implements Robot {
 
 	public async getElementsOnScreen(): Promise<ScreenElement[]> {
 		const response = JSON.parse(this.runCommand(["dump", "ui"])) as DumpUIResponse;
-		return response.data.elements.map(element => ({
-			type: element.type,
-			label: element.label,
-			text: element.text,
-			name: element.name,
-			value: element.value,
-			identifier: element.identifier,
-			rect: element.rect,
-			focused: element.focused,
-		}));
+		return response.data.elements.flatMap(element => flattenUIElement(element));
 	}
 
 	public async setOrientation(orientation: Orientation): Promise<void> {


### PR DESCRIPTION
## Summary
- `MobileDevice.getElementsOnScreen()` (`src/mobile-device.ts`) mapped only the top level of the tree returned by `mobilecli dump ui`, silently discarding each node's `children`. On a default install (mobilecli-routed Android, since #396) this meant `mobile_list_elements_on_screen` returned only 1-2 empty container nodes instead of every addressable control on screen.
- `UIElementResponse` now declares `children?: UIElementResponse[]`, and a new `flattenUIElement()` helper recursively walks the tree, flattening it into the existing flat `ScreenElement[]` shape — no change to the tool's output contract.
- Verified live against a Pixel 9 Pro (Android 16) emulator on the stock Settings app: before the fix, only 1-2 container nodes with no text came back; after, 51 elements including labeled controls (`Internet`, `SIMs`, `Airplane mode`, `Hotspot & tethering`, etc.) with correct `identifier`/`text`.

Fixes #399

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` / eslint passes (ran as part of commit hook)
- [x] Manually verified `mobile_list_elements_on_screen` against a live Android emulator before and after the fix