### PR TITLE
fix: keep ref, selected, checked and enabled on screen elements

### DIFF
--- a/src/mobile-device.ts
+++ b/src/mobile-device.ts
@@ -30,6 +30,7 @@ interface DeviceInfoResponse {
 }
 
 interface UIElementResponse {
+	ref?: string;
 	type: string;
 	label?: string;
 	text?: string;
@@ -43,6 +44,9 @@ interface UIElementResponse {
 		height: number;
 	};
 	focused?: boolean;
+	selected?: boolean;
+	checked?: boolean;
+	enabled?: boolean;
 	children?: UIElementResponse[];
 }
 
@@ -69,7 +73,11 @@ const flattenUIElement = (element: UIElementResponse): ScreenElement[] => {
 		value: element.value,
 		identifier: element.identifier,
 		rect: element.rect,
+		ref: element.ref,
 		focused: element.focused,
+		selected: element.selected,
+		checked: element.checked,
+		enabled: element.enabled,
 	};
 
 	if (!element.children) {

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -32,8 +32,14 @@ export interface ScreenElement {
 	identifier?: string;
 	rect: ScreenElementRect;
 
+	// short reference from the latest ui dump (e.g. "e5"), mobilecli only
+	ref?: string;
+
 	// currently only on android tv
 	focused?: boolean;
+	selected?: boolean;
+	checked?: boolean;
+	enabled?: boolean;
 }
 
 export class ActionableError extends Error {

--- a/src/server.ts
+++ b/src/server.ts
@@ -605,6 +605,7 @@ export const createMcpServer = (): McpServer => {
 
 			const result = elements.map(element => {
 				const out: any = {
+					ref: element.ref,
 					type: element.type,
 					text: element.text,
 					label: element.label,
@@ -619,8 +620,21 @@ export const createMcpServer = (): McpServer => {
 					},
 				};
 
+				// only emit non-default states, otherwise don't confuse llm
 				if (element.focused) {
 					out.focused = true;
+				}
+
+				if (element.selected) {
+					out.selected = true;
+				}
+
+				if (element.checked) {
+					out.checked = true;
+				}
+
+				if (element.enabled === false) {
+					out.enabled = false;
 				}
 
 				return out;

--- a/test/mobile-device.test.ts
+++ b/test/mobile-device.test.ts
@@ -49,4 +49,21 @@ test.describe("MobileDevice", () => {
 			expect(calls[0]).toEqual(["io", "tap", "450,785", "--device", "test-device"]);
 		});
 	});
+
+	test.describe("element state", () => {
+
+		test("getElementsOnScreen should keep ref, selected, checked and enabled from dump ui", async () => {
+			const dump = { status: "ok", data: { elements: [{
+				ref: "e1", type: "Switch", label: "Wi-Fi", rect: { x: 0, y: 0, width: 100, height: 40 },
+				selected: true, checked: true, enabled: false,
+				children: [{ ref: "e2", type: "Text", text: "child", rect: { x: 0, y: 0, width: 10, height: 10 } }],
+			}] } };
+			const { device } = createMockMobileDevice(JSON.stringify(dump));
+			const elements = await device.getElementsOnScreen();
+
+			expect(elements.map(e => e.ref)).toEqual(["e1", "e2"]);
+			expect(elements[0]).toMatchObject({ selected: true, checked: true, enabled: false });
+			expect(elements[1].selected).toBeUndefined();
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- `mobile_list_elements_on_screen` now returns `ref` (e.g. `e5`) plus `selected`, `checked` and `enabled` for each element.
- Only non-default states are emitted (`selected: true`, `checked: true`, `enabled: false`) so output stays compact.
- `ref`, `selected`, `checked`, `enabled` added to `ScreenElement` and the mobilecli `dump ui` response type.

## Why
mobilecli already emits these fields, but `flattenUIElement` and the tool handler silently dropped them. Agents could not tell which tab was selected, whether a toggle was on, or whether a button was disabled, and had no short ref to address elements.

## Test plan
- [x] `npm run lint`, `tsc --noEmit`
- [x] Unit test: nested dump keeps ref/selected/checked/enabled and leaves unset fields undefined