### PR TITLE
docs: update roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ How we help to scale mobile automation:
 | Target | Supported | Setup |
 |---|:---:|---|
 | iOS Simulator | ✅ | Xcode + a booted simulator (`xcrun simctl`) |
-| iOS Real Device | ✅ | go-ios + WebDriverAgent + tunnel |
+| iOS Real Device | ✅ | Device connected over USB and trusted |
 | Android Emulator | ✅ | Android SDK + running emulator (`adb`) |
 | Android Real Device | ✅ | `adb` + USB debugging enabled & authorized |
 
@@ -123,8 +123,6 @@ What you will need to connect MCP with your agent and mobile devices:
 - [Android Platform Tools](https://developer.android.com/tools/releases/platform-tools)
 - [node.js](https://nodejs.org/en/download/) v20+
 - [MCP](https://modelcontextprotocol.io/introduction) supported foundational models or agents, like [Claude MCP](https://modelcontextprotocol.io/quickstart/server), [OpenAI Agent SDK](https://openai.github.io/openai-agents-python/mcp/), [Copilot Studio](https://www.microsoft.com/en-us/microsoft-copilot/blog/copilot-studio/introducing-model-context-protocol-mcp-in-copilot-studio-simplified-integration-with-ai-apps-and-agents/)
-
-For iOS **real devices** (simulators and Android don't need these), you'll also need [go-ios](https://github.com/danielpaulus/go-ios), [WebDriverAgent](https://github.com/appium/WebDriverAgent) installed on the device, and an iOS device tunnel. See the [wiki](https://github.com/mobile-next/mobile-mcp/wiki) for setup.
 
 ## Installation and configuration
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,8 +4,9 @@ This is a living document of planned and in-progress features. Items are roughly
 
 | Feature | Description | Status |
 |---|---|---|
-| **iOS on Device Kit** | Replace WebDriverAgent with our own Device Kit for faster, more reliable iOS automation. | In Progress |
-| **Remove go-ios dependency** | Drop the external `go-ios` dependency entirely as Device Kit takes over. | In Progress |
+| **Background daemon for speedup** | A long-lived background process that keeps device connections, agents and tunnels warm between tool calls, so each call skips discovery and setup and returns in milliseconds instead of seconds. | In Progress |
+| **Element refs in UI dump** | Every element in the UI dump gets a stable `@ref` id that can be passed to tap, type, etc., so agents act on elements without coordinates. | In Progress |
+| **Embed Android Device Kit in the binary** | Ship the Android agent as a dex embedded in the executable and run it via `app_process`, so nothing gets installed on the device and the Device Kit APK goes away. | In Progress |
 | **Streamable HTTP support** | Support the newer MCP Streamable HTTP transport, alongside the existing SSE and stdio transports. | Planned |
 | **File system tools** | List, push, and pull files on the device or within an app container. | Planned |
 | **Better screenshot handling** | Native cropping and scaling, removing the dependency on `sips` and ImageMagick. | Planned |
@@ -20,6 +21,8 @@ Shipped in 2026, most recent first.
 
 | Feature | Description | Date |
 |---|---|---|
+| **iOS on Device Kit** | Replaced WebDriverAgent with our own Device Kit on real iOS devices too. | 2026-09-04 |
+| **Remove go-ios dependency** | Dropped the external `go-ios` dependency entirely. | 2026-09-04 |
 | **iOS Device Kit on Simulator** | Replaced WebDriverAgent with our own Device Kit for iOS Simulator automation. | 2026-05-01 |
 | **List crashes** | Retrieve crash reports from the device. | 2026-05-01 |
 | **SSE authentication** | Optional Bearer-token auth for the SSE server (`--listen` + `MOBILEMCP_AUTH`). | 2026-04-03 |


### PR DESCRIPTION
- Moves **iOS on Device Kit** and **Remove go-ios dependency** to Done Done
- Adds in-progress items: Background daemon for speedup, Element refs in UI dump, Embed Android Device Kit in the binary