### PR TITLE
fix: validate install path, coordinates and mobilecli JSON output

### DIFF
--- a/src/mobile-device.ts
+++ b/src/mobile-device.ts
@@ -1,5 +1,5 @@
 import { Mobilecli } from "./mobilecli";
-import { Button, InstalledApp, Orientation, Robot, ScreenElement, ScreenSize, ScreenshotOptions, SwipeDirection } from "./robot";
+import { ActionableError, Button, InstalledApp, Orientation, Robot, ScreenElement, ScreenSize, ScreenshotOptions, SwipeDirection } from "./robot";
 
 interface InstalledAppsResponse {
 	status: "ok",
@@ -114,8 +114,17 @@ export class MobileDevice implements Robot {
 		return this.mobilecli.executeCommand(fullArgs);
 	}
 
+	private runJsonCommand<T>(args: string[]): T {
+		const output = this.runCommand(args);
+		try {
+			return JSON.parse(output) as T;
+		} catch {
+			throw new ActionableError(`Failed to parse JSON response from mobilecli ${args.join(" ")}`);
+		}
+	}
+
 	public async getScreenSize(): Promise<ScreenSize> {
-		const response = JSON.parse(this.runCommand(["device", "info"])) as DeviceInfoResponse;
+		const response = this.runJsonCommand<DeviceInfoResponse>(["device", "info"]);
 		if (response.data.device.screenSize) {
 			return response.data.device.screenSize;
 		}
@@ -197,7 +206,7 @@ export class MobileDevice implements Robot {
 	}
 
 	public async listApps(): Promise<InstalledApp[]> {
-		const response = JSON.parse(this.runCommand(["apps", "list"])) as InstalledAppsResponse;
+		const response = this.runJsonCommand<InstalledAppsResponse>(["apps", "list"]);
 		return response.data.map(app => ({
 			appName: app.appName || app.packageName,
 			packageName: app.packageName,
@@ -205,7 +214,7 @@ export class MobileDevice implements Robot {
 	}
 
 	public async getForegroundApp(): Promise<InstalledApp> {
-		const response = JSON.parse(this.runCommand(["apps", "foreground"])) as ForegroundAppResponse;
+		const response = this.runJsonCommand<ForegroundAppResponse>(["apps", "foreground"]);
 		return {
 			appName: response.data.appName || response.data.packageName,
 			packageName: response.data.packageName,
@@ -261,7 +270,7 @@ export class MobileDevice implements Robot {
 	}
 
 	public async getElementsOnScreen(): Promise<ScreenElement[]> {
-		const response = JSON.parse(this.runCommand(["dump", "ui"])) as DumpUIResponse;
+		const response = this.runJsonCommand<DumpUIResponse>(["dump", "ui"]);
 		return response.data.elements.flatMap(element => flattenUIElement(element));
 	}
 
@@ -270,7 +279,7 @@ export class MobileDevice implements Robot {
 	}
 
 	public async getOrientation(): Promise<Orientation> {
-		const response = JSON.parse(this.runCommand(["device", "orientation", "get"])) as OrientationResponse;
+		const response = this.runJsonCommand<OrientationResponse>(["device", "orientation", "get"]);
 		return response.data.orientation;
 	}
 
@@ -283,7 +292,7 @@ export class MobileDevice implements Robot {
 	}
 
 	public async getClipboard(): Promise<string> {
-		const response = JSON.parse(this.runCommand(["io", "clipboard", "get"])) as ClipboardResponse;
+		const response = this.runJsonCommand<ClipboardResponse>(["io", "clipboard", "get"]);
 		return response.data.text;
 	}
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ const DEVICE_LOG_FILTER_PATTERN = /^(pid|process|tag|level|subsystem|category|me
 const ALLOWED_SCREENSHOT_EXTENSIONS = [".png", ".jpg", ".jpeg"];
 const DEFAULT_SCREENSHOT_MAX_SIZE = 1024;
 const ALLOWED_RECORDING_EXTENSIONS = [".mp4"];
+const ALLOWED_APP_EXTENSIONS = [".apk", ".ipa", ".zip", ".app"];
 const LOGIN_PROMPT_TIMEOUT_MS = 15000;
 
 interface MobilecliDevice {
@@ -525,6 +526,11 @@ export const createMcpServer = (): McpServer => {
 		},
 		{ readOnlyHint: false, destructiveHint: false, openWorldHint: false },
 		async ({ device, path }) => {
+			validateFileExtension(path, ALLOWED_APP_EXTENSIONS, "install_app");
+			if (!fs.existsSync(path)) {
+				throw new ActionableError(`App file not found: ${path}`);
+			}
+
 			const robot = getRobotFromDevice(device);
 			await robot.installApp(path);
 			return `Installed app from ${path}`;
@@ -568,8 +574,8 @@ export const createMcpServer = (): McpServer => {
 		"Click on the screen at given x,y coordinates. If clicking on an element, use the list_elements_on_screen tool to find the coordinates.",
 		{
 			device: z.string().describe("The device identifier to use. Use mobile_list_available_devices to find which devices are available to you."),
-			x: z.coerce.number().describe("The x coordinate to click on the screen, in pixels"),
-			y: z.coerce.number().describe("The y coordinate to click on the screen, in pixels"),
+			x: z.coerce.number().min(0).describe("The x coordinate to click on the screen, in pixels"),
+			y: z.coerce.number().min(0).describe("The y coordinate to click on the screen, in pixels"),
 		},
 		{ readOnlyHint: false, destructiveHint: false, openWorldHint: true },
 		async ({ device, x, y }) => {
@@ -585,8 +591,8 @@ export const createMcpServer = (): McpServer => {
 		"Double-tap on the screen at given x,y coordinates.",
 		{
 			device: z.string().describe("The device identifier to use. Use mobile_list_available_devices to find which devices are available to you."),
-			x: z.coerce.number().describe("The x coordinate to double-tap, in pixels"),
-			y: z.coerce.number().describe("The y coordinate to double-tap, in pixels"),
+			x: z.coerce.number().min(0).describe("The x coordinate to double-tap, in pixels"),
+			y: z.coerce.number().min(0).describe("The y coordinate to double-tap, in pixels"),
 		},
 		{ readOnlyHint: false, destructiveHint: false, openWorldHint: true },
 		async ({ device, x, y }) => {
@@ -602,8 +608,8 @@ export const createMcpServer = (): McpServer => {
 		"Long press on the screen at given x,y coordinates. If long pressing on an element, use the list_elements_on_screen tool to find the coordinates.",
 		{
 			device: z.string().describe("The device identifier to use. Use mobile_list_available_devices to find which devices are available to you."),
-			x: z.coerce.number().describe("The x coordinate to long press on the screen, in pixels"),
-			y: z.coerce.number().describe("The y coordinate to long press on the screen, in pixels"),
+			x: z.coerce.number().min(0).describe("The x coordinate to long press on the screen, in pixels"),
+			y: z.coerce.number().min(0).describe("The y coordinate to long press on the screen, in pixels"),
 			duration: z.coerce.number().min(1).max(10000).optional().describe("Duration of the long press in milliseconds. Defaults to 500ms."),
 		},
 		{ readOnlyHint: false, destructiveHint: false, openWorldHint: true },
@@ -712,8 +718,8 @@ export const createMcpServer = (): McpServer => {
 		{
 			device: z.string().describe("The device identifier to use. Use mobile_list_available_devices to find which devices are available to you."),
 			direction: z.enum(["up", "down", "left", "right"]).describe("The direction to swipe"),
-			x: z.coerce.number().optional().describe("The x coordinate to start the swipe from, in pixels. If not provided, uses center of screen"),
-			y: z.coerce.number().optional().describe("The y coordinate to start the swipe from, in pixels. If not provided, uses center of screen"),
+			x: z.coerce.number().min(0).optional().describe("The x coordinate to start the swipe from, in pixels. If not provided, uses center of screen"),
+			y: z.coerce.number().min(0).optional().describe("The y coordinate to start the swipe from, in pixels. If not provided, uses center of screen"),
 			distance: z.coerce.number().optional().describe("The distance to swipe in pixels. Defaults to 400 pixels for iOS or 30% of screen dimension for Android"),
 		},
 		{ readOnlyHint: false, destructiveHint: false, openWorldHint: true },


### PR DESCRIPTION
Supersedes #274 by @quantappm. Kept the parts still relevant after the move to the mobilecli robot (legacy android/ios changes, auth token and telemetry opt-out already landed separately):

- `mobile_install_app` validates file extension and that the file exists
- x/y coordinates are `min(0)`
- `MobileDevice` wraps mobilecli JSON parsing in an `ActionableError`

Commit is authored by Quan so contributor credit is preserved.