### PR TITLE
feat: add mobile_batch_commands tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ How we help to scale mobile automation:
 - **`mobile_get_device_logs`** - Collect live device logs (logcat on Android, unified log on iOS), optionally saved to a file
 - **`mobile_list_crashes`** - List crash reports available on the device
 - **`mobile_get_crash`** - Get the full content of a crash report by its ID
+- **`mobile_batch_commands`** - Run multiple tools in sequence in a single call (e.g. click, type, click), optionally listing screen elements at the end
 
 ## 🏗️ Mobile MCP Architecture
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -79,10 +79,10 @@ export const createMcpServer = (): McpServer => {
 	type ToolCallback = (args: any, telemetry: Record<string, string | number>) => Promise<string>;
 
 	// ponytail: batch calls tool callbacks directly, bypassing mcp transport
-	const toolCallbacks: Record<string, ToolCallback> = {};
+	const toolCallbacks = new Map<string, { callback: ToolCallback; paramsSchema: ZodSchemaShape }>();
 
 	const tool = (name: string, title: string, description: string, paramsSchema: ZodSchemaShape, annotations: ToolAnnotations, cb: ToolCallback) => {
-		toolCallbacks[name] = cb;
+		toolCallbacks.set(name, { callback: cb, paramsSchema });
 		server.registerTool(name, {
 			title,
 			description,
@@ -1131,13 +1131,18 @@ export const createMcpServer = (): McpServer => {
 					throw new ActionableError("mobile_batch_commands cannot be nested");
 				}
 
-				const cb = toolCallbacks[step.name];
-				if (!cb) {
+				if (step.name === "mobile_take_screenshot") {
+					throw new ActionableError("mobile_take_screenshot returns an image and cannot be used in a batch, use mobile_save_screenshot instead");
+				}
+
+				const entry = toolCallbacks.get(step.name);
+				if (!entry) {
 					throw new ActionableError(`Unknown tool in step ${i + 1}: ${step.name}`);
 				}
 
 				try {
-					const output = await cb({ device, ...step.arguments }, {});
+					const args = z.object(entry.paramsSchema).parse({ device, ...step.arguments });
+					const output = await entry.callback(args, {});
 					results.push(`Step ${i + 1} (${step.name}): ${output}`);
 				} catch (error: any) {
 					results.push(`Step ${i + 1} (${step.name}) failed: ${error.message}`);
@@ -1148,7 +1153,7 @@ export const createMcpServer = (): McpServer => {
 			}
 
 			if (listElementsAtEnd) {
-				results.push(await toolCallbacks["mobile_list_elements_on_screen"]({ device }, {}));
+				results.push(await toolCallbacks.get("mobile_list_elements_on_screen")!.callback({ device }, {}));
 			}
 
 			return results.join("\n");

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,7 +76,13 @@ export const createMcpServer = (): McpServer => {
 		openWorldHint?: boolean;
 	}
 
-	const tool = (name: string, title: string, description: string, paramsSchema: ZodSchemaShape, annotations: ToolAnnotations, cb: (args: any, telemetry: Record<string, string | number>) => Promise<string>) => {
+	type ToolCallback = (args: any, telemetry: Record<string, string | number>) => Promise<string>;
+
+	// ponytail: batch calls tool callbacks directly, bypassing mcp transport
+	const toolCallbacks: Record<string, ToolCallback> = {};
+
+	const tool = (name: string, title: string, description: string, paramsSchema: ZodSchemaShape, annotations: ToolAnnotations, cb: ToolCallback) => {
+		toolCallbacks[name] = cb;
 		server.registerTool(name, {
 			title,
 			description,
@@ -1097,6 +1103,55 @@ export const createMcpServer = (): McpServer => {
 			ensureMobilecliAvailable();
 			const response = mobilecli.crashesGet(device, id);
 			return response.data.content;
+		}
+	);
+
+	tool(
+		"mobile_batch_commands",
+		"Batch Commands",
+		"Run multiple tools in sequence in a single call, e.g. click, type, click, type. Use this to fill forms or perform multi-step flows without round-trips. The device argument is applied to every step unless a step provides its own.",
+		{
+			device: z.string().describe("The device identifier to use. Use mobile_list_available_devices to find which devices are available to you."),
+			steps: z.array(z.object({
+				name: z.string().describe("Tool name, e.g. mobile_click_on_screen_at_coordinates"),
+				arguments: z.record(z.string(), z.any()).describe("Arguments for the tool, same as calling it directly"),
+			})).min(1).describe("Tools to run, in order"),
+			stopOnError: z.boolean().optional().describe("Stop at the first failing step. Defaults to true"),
+			listElementsAtEnd: z.boolean().optional().describe("Run mobile_list_elements_on_screen after the last step and include its result. Defaults to false"),
+		},
+		{ readOnlyHint: false, destructiveHint: true, openWorldHint: true },
+		async ({ device, steps, stopOnError, listElementsAtEnd }, telemetry) => {
+			const shouldStopOnError = stopOnError ?? true;
+			const results: string[] = [];
+			telemetry.StepCount = steps.length;
+
+			for (let i = 0; i < steps.length; i++) {
+				const step = steps[i];
+				if (step.name === "mobile_batch_commands") {
+					throw new ActionableError("mobile_batch_commands cannot be nested");
+				}
+
+				const cb = toolCallbacks[step.name];
+				if (!cb) {
+					throw new ActionableError(`Unknown tool in step ${i + 1}: ${step.name}`);
+				}
+
+				try {
+					const output = await cb({ device, ...step.arguments }, {});
+					results.push(`Step ${i + 1} (${step.name}): ${output}`);
+				} catch (error: any) {
+					results.push(`Step ${i + 1} (${step.name}) failed: ${error.message}`);
+					if (shouldStopOnError) {
+						break;
+					}
+				}
+			}
+
+			if (listElementsAtEnd) {
+				results.push(await toolCallbacks["mobile_list_elements_on_screen"]({ device }, {}));
+			}
+
+			return results.join("\n");
 		}
 	);
 

--- a/test/server-annotations.test.ts
+++ b/test/server-annotations.test.ts
@@ -39,6 +39,7 @@ const expectedAnnotations: ToolAnnotationMatrix = {
 	mobile_stop_screen_recording: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
 	mobile_list_crashes: { readOnlyHint: true, openWorldHint: true },
 	mobile_get_crash: { readOnlyHint: true, openWorldHint: true },
+	mobile_batch_commands: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
 };
 
 test("describes every tool's side effects and interaction domain", async () => {

--- a/test/server-batch.test.ts
+++ b/test/server-batch.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { createMcpServer } from "../src/server";
+
+const createConnectedClient = async () => {
+	process.env.MOBILEMCP_DISABLE_TELEMETRY = "1";
+	const server = createMcpServer();
+	const client = new Client({ name: "batch-test", version: "1.0.0" });
+	const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+	await server.connect(serverTransport);
+	await client.connect(clientTransport);
+	return client;
+};
+
+const runBatch = async (client: Client, args: Record<string, unknown>): Promise<string> => {
+	const result: any = await client.callTool({ name: "mobile_batch_commands", arguments: args });
+	return result.content[0].text;
+};
+
+test("rejects a step that names an unknown tool", async () => {
+	const client = await createConnectedClient();
+	const text = await runBatch(client, { device: "nope", steps: [{ name: "mobile_does_not_exist", arguments: {} }] });
+	expect(text).toContain("Unknown tool in step 1: mobile_does_not_exist");
+});
+
+test("continues past failing steps when stopOnError is false", async () => {
+	const client = await createConnectedClient();
+	const text = await runBatch(client, {
+		device: "no-such-device",
+		stopOnError: false,
+		steps: [
+			{ name: "mobile_click_on_screen_at_coordinates", arguments: { x: 1, y: 1 } },
+			{ name: "mobile_type_keys", arguments: { text: "hi", submit: false } },
+		],
+	});
+	expect(text).toContain("Step 1 (mobile_click_on_screen_at_coordinates) failed");
+	expect(text).toContain("Step 2 (mobile_type_keys) failed");
+});
+
+test("stops at the first failing step by default", async () => {
+	const client = await createConnectedClient();
+	const text = await runBatch(client, {
+		device: "no-such-device",
+		steps: [
+			{ name: "mobile_click_on_screen_at_coordinates", arguments: { x: 1, y: 1 } },
+			{ name: "mobile_type_keys", arguments: { text: "hi", submit: false } },
+		],
+	});
+	expect(text).toContain("Step 1 (mobile_click_on_screen_at_coordinates) failed");
+	expect(text).not.toContain("Step 2");
+});

--- a/test/server-batch.test.ts
+++ b/test/server-batch.test.ts
@@ -51,3 +51,25 @@ test("stops at the first failing step by default", async () => {
 	expect(text).toContain("Step 1 (mobile_click_on_screen_at_coordinates) failed");
 	expect(text).not.toContain("Step 2");
 });
+
+test("rejects a step named after an inherited object property", async () => {
+	const client = await createConnectedClient();
+	const text = await runBatch(client, { device: "nope", steps: [{ name: "constructor", arguments: {} }] });
+	expect(text).toContain("Unknown tool in step 1: constructor");
+});
+
+test("rejects mobile_take_screenshot with a hint to use mobile_save_screenshot", async () => {
+	const client = await createConnectedClient();
+	const text = await runBatch(client, { device: "nope", steps: [{ name: "mobile_take_screenshot", arguments: {} }] });
+	expect(text).toContain("use mobile_save_screenshot instead");
+});
+
+test("validates step arguments against the target tool schema", async () => {
+	const client = await createConnectedClient();
+	const text = await runBatch(client, {
+		device: "nope",
+		steps: [{ name: "mobile_click_on_screen_at_coordinates", arguments: { x: "not-a-number", y: 1 } }],
+	});
+	expect(text).toContain("Step 1 (mobile_click_on_screen_at_coordinates) failed");
+	expect(text).toContain("x");
+});


### PR DESCRIPTION
## Summary
- New `mobile_batch_commands` tool: runs a list of `{ name, arguments }` steps in sequence in one MCP call. `device` is injected into every step.
- `stopOnError` (default true) stops at the first failing step; otherwise all steps run and each result/failure is reported.
- `listElementsAtEnd` appends the output of `mobile_list_elements_on_screen` after the last step.
- Tool callbacks are now kept in a map inside `tool()` so batch invokes them in-process; no transport round-trips.
- Nested batches and unknown tool names return an `ActionableError`.

## Test plan
- [x] `test/server-batch.test.ts`: unknown tool rejected, continue-on-error, stop-on-error
- [x] `test/server-annotations.test.ts` updated with new tool annotations
- [x] Manual: fill a form on a device with click + type steps and `listElementsAtEnd: true`