### PR TITLE
perf: cache Robot per device id

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -173,7 +173,7 @@ export const createMcpServer = (): McpServer => {
 		}
 	};
 
-	// ponytail: cache per device id, saves ~0.2s (mobilecli --version + devices) on every tool call
+	// cache per device id, saves ~0.2s (mobilecli --version + devices) on every tool call
 	const robotCache = new Map<string, Robot>();
 
 	const getRobotFromDevice = (deviceId: string): Robot => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -173,7 +173,21 @@ export const createMcpServer = (): McpServer => {
 		}
 	};
 
+	// ponytail: cache per device id, saves ~0.2s (mobilecli --version + devices) on every tool call
+	const robotCache = new Map<string, Robot>();
+
 	const getRobotFromDevice = (deviceId: string): Robot => {
+		const cached = robotCache.get(deviceId);
+		if (cached) {
+			return cached;
+		}
+
+		const robot = createRobotFromDevice(deviceId);
+		robotCache.set(deviceId, robot);
+		return robot;
+	};
+
+	const createRobotFromDevice = (deviceId: string): Robot => {
 
 		// from now on, we must have mobilecli working
 		ensureMobilecliAvailable();


### PR DESCRIPTION
## Summary
- `getRobotFromDevice` spawned `mobilecli --version` and `mobilecli devices` on every tool call, about 0.2s of the ~0.5s a click costs
- cache the `Robot` per device id after the first successful lookup; a wrong device id still throws on the first call

Measured on Pixel 9 Pro emulator per click: `--version` 0.04s, `devices` 0.15s, `io tap` 0.25-0.33s. Expected ~35% faster tool calls; the remaining cost is `adb shell input tap` itself.

## Test plan
- [x] `npm run lint`, `tsc --noEmit`
- [x] `npm test`: same 4 live-device failures as on main (android + iphone-simulator), 55 passed