### PR TITLE
ci: skip build workflow when only markdown files change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,13 @@ on:
       - main
     tags:
       - "*.*.*"
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add `paths-ignore: ["**.md"]` to the `push` and `pull_request` triggers of the Build workflow
- Docs-only PRs like #432 no longer run the full build

Safe to skip: `main-branch-protection` ruleset has no required status checks, so markdown-only PRs won't wait on a check that never runs.