### PR TITLE
ci: split publish out of build and gate it on e2e_test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ on:
 jobs:
   build:
     permissions:
-      id-token: write
       contents: read
 
     runs-on: ubuntu-latest
@@ -43,8 +42,31 @@ jobs:
     - name: Lint
       run: npm run lint
 
+    - name: Build
+      run: |
+        npm run build
+
+  publish_npm:
+    runs-on: ubuntu-latest
+    needs: [build, e2e_test]
+    if: github.ref_type == 'tag'
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Use Node.js 24
+      uses: actions/setup-node@v5
+      with:
+        node-version: '24'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install dependencies
+      run: npm ci --ignore-scripts
+
     - name: Update version
-      if: github.ref_type == 'tag'
       env:
         VERSION: ${{ github.ref_name }}
       run: |
@@ -55,12 +77,10 @@ jobs:
         npm run build
 
     - name: Publish
-      if: github.ref_type == 'tag'
       run: |
         npm publish --access public --provenance
 
     - name: Publish on github mcp registry
-      if: github.ref_type == 'tag'
       env:
         VERSION: ${{ github.ref_name }}
       run: |
@@ -76,7 +96,7 @@ jobs:
     # macos runner (arm64) so sharp bundles darwin-arm64 native libs;
     # the bundle targets macOS Apple Silicon to fit Smithery's 25MB cap
     runs-on: macos-latest
-    needs: build
+    needs: [build, e2e_test]
     if: github.ref_type == 'tag'
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Move npm + GitHub MCP registry publishing out of `build` into a new tag-only `publish_npm` job
- Both `publish_npm` and `publish_mcpb` now `needs: [build, e2e_test]`, so a failed e2e run blocks the release
- `build` drops `id-token: write` since it no longer publishes

Job graph on a tag push:
```
build -> e2e_test -> publish_npm  (npm + MCP registry)
                  -> publish_mcpb (Smithery)
```

## Test plan
- [ ] Workflow YAML parses (checked locally)
- [ ] PR run: only `build` and `e2e_test` execute
- [ ] Next tag: publish jobs start only after `e2e_test` succeeds