### PR TITLE
fix: wait for mobilecli to confirm screen recording started

### DIFF
--- a/src/mobilecli.ts
+++ b/src/mobilecli.ts
@@ -67,6 +67,7 @@ export interface MobilecliDevicesResponse {
 
 const TIMEOUT = 30000;
 const MAX_BUFFER_SIZE = 1024 * 1024 * 8;
+const SCREEN_RECORDING_STARTED = "Screen recording has started";
 const DEFAULT_ALLOCATE_TIMEOUT_SECONDS = 900; // matches mobilecli's own "remote allocate --wait" default
 
 export class Mobilecli {
@@ -95,6 +96,60 @@ export class Mobilecli {
 		const binaryPath = this.getPath();
 		return spawn(binaryPath, args, {
 			stdio: ["ignore", captureOutput ? "pipe" : "ignore", captureOutput ? "pipe" : "ignore"],
+		});
+	}
+
+	/**
+	 * Spawns `mobilecli screenrecord` and resolves only once mobilecli reports that
+	 * recording has started. Rejects on spawn error, early exit, or startup timeout.
+	 */
+	public startScreenRecording(args: string[]): Promise<ChildProcess> {
+		const child = this.spawnCommand(args, true);
+		const stdout = child.stdout!;
+		const stderr = child.stderr!;
+
+		return new Promise((resolve, reject) => {
+			let output = "";
+			let settled = false;
+
+			const finish = () => {
+				settled = true;
+				clearTimeout(timer);
+				stdout.off("data", onData);
+				stderr.off("data", onData);
+				stdout.resume();
+				stderr.resume();
+			};
+
+			const fail = (error: Error) => {
+				if (settled) {
+					return;
+				}
+
+				finish();
+				reject(error);
+			};
+
+			const onData = (chunk: Buffer) => {
+				output = (output + chunk.toString()).slice(-MAX_BUFFER_SIZE);
+				if (!settled && output.includes(SCREEN_RECORDING_STARTED)) {
+					finish();
+					resolve(child);
+				}
+			};
+
+			const timer = setTimeout(() => {
+				child.kill();
+				fail(new Error("Timed out waiting for mobilecli to start screen recording"));
+			}, TIMEOUT);
+
+			stdout.on("data", onData);
+			stderr.on("data", onData);
+			child.once("error", fail);
+			child.once("exit", (code, signal) => {
+				const status = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
+				fail(new Error(output.trim() || `mobilecli exited before screen recording started (${status})`));
+			});
 		});
 	}
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -999,12 +999,12 @@ export const createMcpServer = (): McpServer => {
 
 			const outputPath = output || path.join(os.tmpdir(), `screen-recording-${Date.now()}.mp4`);
 
-			const args = ["screenrecord", "--device", device, "--output", outputPath, "--silent"];
+			const args = ["screenrecord", "--device", device, "--output", outputPath];
 			if (timeLimit !== undefined) {
 				args.push("--time-limit", String(timeLimit));
 			}
 
-			const child = mobilecli.spawnCommand(args);
+			const child = await mobilecli.startScreenRecording(args);
 
 			const cleanup = () => {
 				activeRecordings.delete(device);

--- a/test/mobilecli.test.ts
+++ b/test/mobilecli.test.ts
@@ -116,4 +116,37 @@ test.describe("mobilecli", () => {
 			expect(calls[0].args).toEqual(["devices", "--include-offline", "--platform", "android", "--type", "emulator"]);
 		});
 	});
+
+	test.describe("startScreenRecording", () => {
+		test.beforeEach(() => {
+			process.env.MOBILECLI_PATH = process.execPath;
+		});
+
+		test.afterEach(() => {
+			delete process.env.MOBILECLI_PATH;
+		});
+
+		test("rejects when mobilecli exits before reporting that recording started", async () => {
+			const mobilecli = new Mobilecli();
+
+			await expect(mobilecli.startScreenRecording([
+				"-e",
+				"process.stderr.write('device not found\\n'); process.exit(1);",
+			])).rejects.toThrow("device not found");
+		});
+
+		test("resolves only after mobilecli reports that recording started", async () => {
+			const mobilecli = new Mobilecli();
+			const child = await mobilecli.startScreenRecording([
+				"-e",
+				"process.stderr.write('Screen recording has started\\n'); setTimeout(() => {}, 5000);",
+			]);
+
+			try {
+				expect(child.exitCode).toBeNull();
+			} finally {
+				child.kill();
+			}
+		});
+	});
 });


### PR DESCRIPTION
## Problem

`mobile_start_screen_recording` spawned `mobilecli screenrecord --silent` with stdio ignored and returned "started" immediately. If mobilecli failed at startup (device not found, agent missing, etc), the tool still reported success and the failure only surfaced later as a missing file.

## Fix

- New `Mobilecli.startScreenRecording()` pipes stdout/stderr and resolves only after mobilecli prints `Screen recording has started`.
- Rejects on spawn error, early exit (surfacing mobilecli's own error text), or a 30s startup timeout.
- Drop `--silent` so the sentinel is emitted.

This is the salvageable part of #383 by @Cosm1cAC. The adb-serial mapping in that PR is no longer needed since device IDs now come from mobilecli directly.

## Test plan

- [x] `npm run test -- test/mobilecli.test.ts` (2 new tests: early-exit rejection, sentinel resolution)
- [x] tsc + eslint clean
- [ ] manual: start/stop recording on a device, and start with a bogus device id to see the error surface

Refs #359