### PR TITLE
chore: update telemetry

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -500,7 +500,7 @@ Mobile Next Mobile MCP を実行する前に、モバイルプラットフォー
 
 ### テレメトリ
 
-Mobile MCP は PostHog を通じて匿名の利用テレメトリを収集します。無効にするには、環境変数 `MOBILEMCP_DISABLE_TELEMETRY` を設定します:
+Mobile MCP は PostHog と Scarf を通じて匿名の利用テレメトリを収集します。無効にするには、環境変数 `MOBILEMCP_DISABLE_TELEMETRY` を設定します:
 
 ```bash
 MOBILEMCP_DISABLE_TELEMETRY=1 npx @mobilenext/mobile-mcp@latest

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ Make sure you have your mobile platform SDKs (Xcode, Android SDK) installed and 
 
 ### Telemetry
 
-Mobile MCP collects anonymous usage telemetry via PostHog. To disable it, set the `MOBILEMCP_DISABLE_TELEMETRY` environment variable:
+Mobile MCP collects anonymous usage telemetry via PostHog and Scarf. To disable it, set the `MOBILEMCP_DISABLE_TELEMETRY` environment variable:
 
 ```bash
 MOBILEMCP_DISABLE_TELEMETRY=1 npx @mobilenext/mobile-mcp@latest

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -500,7 +500,7 @@ Gmail to contacts "team@example.com".
 
 ### 遥测
 
-Mobile MCP 通过 PostHog 收集匿名的使用情况遥测数据。若要关闭，请设置环境变量 `MOBILEMCP_DISABLE_TELEMETRY`:
+Mobile MCP 通过 PostHog 和 Scarf 收集匿名的使用情况遥测数据。若要关闭，请设置环境变量 `MOBILEMCP_DISABLE_TELEMETRY`:
 
 ```bash
 MOBILEMCP_DISABLE_TELEMETRY=1 npx @mobilenext/mobile-mcp@latest

--- a/src/server.ts
+++ b/src/server.ts
@@ -90,6 +90,7 @@ export const createMcpServer = (): McpServer => {
 			inputSchema: paramsSchema,
 			annotations,
 		}, (async (args: any, _extra: any) => {
+			scarf();
 			try {
 				trace(`Invoking ${name} with args: ${JSON.stringify(args)}`);
 				const start = +new Date();
@@ -161,6 +162,17 @@ export const createMcpServer = (): McpServer => {
 		} catch (err: any) {
 			// ignore
 		}
+	};
+
+	// ponytail: scarf.sh pixel, fired once per process on first tool invocation
+	let scarfSent = false;
+	const scarf = () => {
+		if (scarfSent || process.env.MOBILEMCP_DISABLE_TELEMETRY) {
+			return;
+		}
+
+		scarfSent = true;
+		fetch("https://static.scarf.sh/a.png?x-pxid=f238110d-fcbb-479a-bdda-d47716ec4f07").catch(() => {});
 	};
 
 	const mobilecli = new Mobilecli();


### PR DESCRIPTION
Add scarf.sh pixel, fired once per process on first tool invocation. Respects `MOBILEMCP_DISABLE_TELEMETRY`. README (en/ja/zh-CN) now says PostHog and Scarf.