### PR TITLE
fix: time-bound mobilecli invocations so a hang cannot deadlock the server

### DIFF
--- a/src/mobilecli.ts
+++ b/src/mobilecli.ts
@@ -66,6 +66,7 @@ export interface MobilecliDevicesResponse {
 }
 
 const TIMEOUT = 30000;
+const AGENT_INSTALL_TIMEOUT = 300000; // installing the device agent can take several minutes
 const MAX_BUFFER_SIZE = 1024 * 1024 * 8;
 const DEFAULT_ALLOCATE_TIMEOUT_SECONDS = 900; // matches mobilecli's own "remote allocate --wait" default
 
@@ -81,12 +82,12 @@ export class Mobilecli {
 		return this.path;
 	}
 
-	public executeCommand(args: string[], timeoutMs?: number): string {
+	// Every mobilecli invocation must be time-bounded: execFileSync blocks the
+	// whole event loop, so a single hung subprocess would otherwise make the
+	// server unresponsive to every request.
+	public executeCommand(args: string[], timeoutMs: number = TIMEOUT): string {
 		const path = this.getPath();
-		const options: { encoding: "utf8"; timeout?: number } = { encoding: "utf8" };
-		if (timeoutMs !== undefined) {
-			options.timeout = timeoutMs;
-		}
+		const options: { encoding: "utf8"; timeout: number } = { encoding: "utf8", timeout: timeoutMs };
 
 		return execFileSync(path, args, options).toString().trim();
 	}
@@ -229,7 +230,7 @@ export class Mobilecli {
 	}
 
 	agentInstall(deviceId: string): void {
-		this.executeCommand(["agent", "install", "--device", deviceId]);
+		this.executeCommand(["agent", "install", "--device", deviceId], AGENT_INSTALL_TIMEOUT);
 	}
 
 	getDevices(options?: MobilecliDevicesOptions): MobilecliDevicesResponse {

--- a/test/mobilecli.test.ts
+++ b/test/mobilecli.test.ts
@@ -1,4 +1,7 @@
 import { test, expect } from "@playwright/test";
+import { writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Mobilecli } from "../src/mobilecli";
 
 type ExecuteCommandCall = {
@@ -114,6 +117,27 @@ test.describe("mobilecli", () => {
 
 			expect(calls.length).toBe(1);
 			expect(calls[0].args).toEqual(["devices", "--include-offline", "--platform", "android", "--type", "emulator"]);
+		});
+	});
+
+	test.describe("executeCommand", () => {
+		test.skip(process.platform === "win32", "uses a POSIX shell script");
+
+		test("should time out instead of blocking forever when the command hangs", () => {
+			const scriptPath = join(tmpdir(), `mobilecli-hang-${process.pid}.sh`);
+			writeFileSync(scriptPath, "#!/bin/sh\nsleep 60\n", { mode: 0o755 });
+
+			try {
+				process.env.MOBILECLI_PATH = scriptPath;
+				const hanging = new Mobilecli();
+				const started = Date.now();
+
+				expect(() => hanging.executeCommand(["devices"], 1000)).toThrow();
+				expect(Date.now() - started).toBeLessThan(15000);
+			} finally {
+				delete process.env.MOBILECLI_PATH;
+				rmSync(scriptPath, { force: true });
+			}
 		});
 	});
 });


### PR DESCRIPTION
Fixes #438. Underlying hang: mobile-next/mobilecli#407.

`executeCommand` passed no timeout to `execFileSync` for most subcommands, so one hung mobilecli child (e.g. `devices` on a locked keyring) blocked the Node event loop and made **every** MCP request time out while the process stayed alive.

Changes:

- `executeCommand(args, timeoutMs = TIMEOUT)` - every invocation is now bounded by the existing 30s `TIMEOUT` unless a caller passes something longer
- `agentInstall` gets a 5-minute bound, since installing the device agent can legitimately take a while
- regression test: a hanging command throws after the timeout instead of blocking forever (POSIX-only, skipped on Windows)

Verified locally:

- `npm run build` and `npm run lint` clean
- `npx playwright test test/mobilecli.test.ts` - 10/10 pass, including the new timeout test
- with `MOBILECLI_PATH` pointing at a sleeping script, the call throws ~1s after a 1s timeout instead of blocking the server

This is the defense-in-depth half; #407 fixes the mobilecli side.
