### PR TITLE
docs: sync ja and zh-CN READMEs with English

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -404,7 +404,7 @@ npx @mobilenext/mobile-mcp@latest --listen 0.0.0.0:3000
 
 その後、MCP クライアントが `http://<host>:3000/mcp`（TLS 配下なら `https://…/mcp`）に接続するよう設定します。エンドポイントは Streamable HTTP（`/mcp` への `POST`）を受け付けます。リモートモードは **ステートレス** で（セッション親和性不要）、Smithery などの水平スケールするホストとも相性が良いです。
 
-> **移行メモ:** 以前の `--listen` は非推奨の HTTP+SSE を `/mcp` で提供していました。クライアントは `http(s)://host:port/mcp` に対して Streamable HTTP を使う必要があります。以前の純粋な SSE フローは `/mcp` では利用できなくなりました。詳細は [#98](https://github.com/mobile-next/mobile-mcp/issues/98) を参照してください。
+> **移行メモ:** 以前の `--listen` は非推奨の HTTP+SSE を `/mcp` で提供していました。クライアントは `http(s)://host:port/mcp` に対して Streamable HTTP を使う必要があります。以前の純粋な SSE フローは `/mcp` では利用できなくなりました。
 
 localhost にバインドする場合、Host ヘッダーによる DNS リバインディング保護が自動的に有効になります。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -112,6 +112,7 @@ https://github.com/user-attachments/assets/bb084777-beb3-4930-ae6f-8d3fe694ddde
 - **`mobile_get_device_logs`** - デバイスのライブログを収集します（Android は logcat、iOS は unified log）。ファイルへの保存も可能です
 - **`mobile_list_crashes`** - デバイス上で利用可能なクラッシュレポートを一覧表示します
 - **`mobile_get_crash`** - ID を指定してクラッシュレポートの全文を取得します
+- **`mobile_batch_commands`** - 複数のツールを 1 回の呼び出しで順番に実行します（例: クリック、入力、クリック）。最後に画面上の要素を一覧表示することもできます
 
 ## 🏗️ Mobile MCP のアーキテクチャ
 
@@ -401,9 +402,11 @@ npx @mobilenext/mobile-mcp@latest --listen 3000
 npx @mobilenext/mobile-mcp@latest --listen 0.0.0.0:3000
 ```
 
-その後、MCP クライアントが `http://<host>:3000/mcp`（TLS 配下なら `https://…/mcp`）に接続するよう設定します。エンドポイントは Streamable HTTP（`/mcp` への `POST`）を受け付けます。リモートモードは **ステートレス** です（セッション親和性不要）。
+その後、MCP クライアントが `http://<host>:3000/mcp`（TLS 配下なら `https://…/mcp`）に接続するよう設定します。エンドポイントは Streamable HTTP（`/mcp` への `POST`）を受け付けます。リモートモードは **ステートレス** で（セッション親和性不要）、Smithery などの水平スケールするホストとも相性が良いです。
 
-> **移行メモ:** 以前の `--listen` は非推奨の HTTP+SSE を `/mcp` で提供していました。クライアントは `http(s)://host:port/mcp` に対して Streamable HTTP を使う必要があります。 [#98](https://github.com/mobile-next/mobile-mcp/issues/98)
+> **移行メモ:** 以前の `--listen` は非推奨の HTTP+SSE を `/mcp` で提供していました。クライアントは `http(s)://host:port/mcp` に対して Streamable HTTP を使う必要があります。以前の純粋な SSE フローは `/mcp` では利用できなくなりました。詳細は [#98](https://github.com/mobile-next/mobile-mcp/issues/98) を参照してください。
+
+localhost にバインドする場合、Host ヘッダーによる DNS リバインディング保護が自動的に有効になります。
 
 #### 認可
 

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ npx @mobilenext/mobile-mcp@latest --listen 0.0.0.0:3000
 
 Then configure your MCP client to connect to `http://<host>:3000/mcp` (or `https://…/mcp` behind TLS). The endpoint accepts Streamable HTTP (`POST` on `/mcp`); remote mode is **stateless** (no session affinity required), which works well with Smithery and other horizontal hosts.
 
-> **Migration note:** `--listen` previously served the deprecated HTTP+SSE transport on `/mcp`. Clients must use Streamable HTTP against `http(s)://host:port/mcp`. The old pure-SSE flow on `/mcp` is no longer available. See [#98](https://github.com/mobile-next/mobile-mcp/issues/98).
+> **Migration note:** `--listen` previously served the deprecated HTTP+SSE transport on `/mcp`. Clients must use Streamable HTTP against `http(s)://host:port/mcp`. The old pure-SSE flow on `/mcp` is no longer available.
 
 When binding to localhost, Host-header DNS rebinding protection is enabled automatically.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -404,7 +404,7 @@ npx @mobilenext/mobile-mcp@latest --listen 0.0.0.0:3000
 
 然后将你的 MCP 客户端配置为连接 `http://<host>:3000/mcp`（TLS 后可用 `https://…/mcp`）。该端点接受 Streamable HTTP（对 `/mcp` 的 `POST`）；远程模式为 **无状态**（无需会话亲和性），非常适合 Smithery 等水平扩展的托管平台。
 
-> **迁移说明:** 此前 `--listen` 在 `/mcp` 上提供已弃用的 HTTP+SSE。客户端需对 `http(s)://host:port/mcp` 使用 Streamable HTTP。`/mcp` 上原有的纯 SSE 流程已不再可用。见 [#98](https://github.com/mobile-next/mobile-mcp/issues/98)。
+> **迁移说明:** 此前 `--listen` 在 `/mcp` 上提供已弃用的 HTTP+SSE。客户端需对 `http(s)://host:port/mcp` 使用 Streamable HTTP。`/mcp` 上原有的纯 SSE 流程已不再可用。
 
 绑定到 localhost 时，会自动启用基于 Host 请求头的 DNS 重绑定防护。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -112,6 +112,7 @@ https://github.com/user-attachments/assets/bb084777-beb3-4930-ae6f-8d3fe694ddde
 - **`mobile_get_device_logs`** - 采集设备实时日志（Android 上为 logcat，iOS 上为 unified log），可选择保存到文件
 - **`mobile_list_crashes`** - 列出设备上可用的崩溃报告
 - **`mobile_get_crash`** - 按 ID 获取崩溃报告的完整内容
+- **`mobile_batch_commands`** - 在一次调用中按顺序运行多个工具（例如点击、输入、点击），可选择在最后列出屏幕元素
 
 ## 🏗️ Mobile MCP 架构
 
@@ -401,9 +402,11 @@ npx @mobilenext/mobile-mcp@latest --listen 3000
 npx @mobilenext/mobile-mcp@latest --listen 0.0.0.0:3000
 ```
 
-然后将你的 MCP 客户端配置为连接 `http://<host>:3000/mcp`（TLS 后可用 `https://…/mcp`）。该端点接受 Streamable HTTP（对 `/mcp` 的 `POST`）；远程模式为 **无状态**（无需会话亲和性）。
+然后将你的 MCP 客户端配置为连接 `http://<host>:3000/mcp`（TLS 后可用 `https://…/mcp`）。该端点接受 Streamable HTTP（对 `/mcp` 的 `POST`）；远程模式为 **无状态**（无需会话亲和性），非常适合 Smithery 等水平扩展的托管平台。
 
-> **迁移说明:** 此前 `--listen` 在 `/mcp` 上提供已弃用的 HTTP+SSE。客户端需对 `http(s)://host:port/mcp` 使用 Streamable HTTP。见 [#98](https://github.com/mobile-next/mobile-mcp/issues/98)。
+> **迁移说明:** 此前 `--listen` 在 `/mcp` 上提供已弃用的 HTTP+SSE。客户端需对 `http(s)://host:port/mcp` 使用 Streamable HTTP。`/mcp` 上原有的纯 SSE 流程已不再可用。见 [#98](https://github.com/mobile-next/mobile-mcp/issues/98)。
+
+绑定到 localhost 时，会自动启用基于 Host 请求头的 DNS 重绑定防护。
 
 #### 认证授权
 
@@ -571,4 +574,4 @@ Mobile MCP 是驱动真实移动设备这套工具集中的一环:
 
 Mobile MCP 在本地运行，仅与你所连接的设备通信。
 有关数据收集、使用、保留以及联系方式，请查看 Mobile Next 隐私政策:
-https://mobilenext.ai/privacy。
+[https://mobilenext.ai/privacy](https://mobilenext.ai/privacy)。

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Shipped in 2026, most recent first.
 
 | Feature | Description | Date |
 |---|---|---|
-| **Streamable HTTP support** | `--listen` serves MCP Streamable HTTP on `/mcp` (stateless). Replaces deprecated SSE on `/mcp`. Closes [#98](https://github.com/mobile-next/mobile-mcp/issues/98). | 2026-09-11 |
+| **Streamable HTTP support** | `--listen` serves MCP Streamable HTTP on `/mcp` (stateless). Replaces deprecated SSE on `/mcp`. | 2026-09-11 |
 | **Device logs** | Read device system logs — syslog, console, and logcat. | 2026-09-08 |
 | **Background daemon for speedup** | A long-lived background process that keeps device connections, agents and tunnels warm between tool calls, so each call skips discovery and setup and returns in milliseconds instead of seconds. | 2026-09-08 |
 | **Element refs in UI dump** | Every element in the UI dump gets a stable `@ref` id that can be passed to tap, type, etc., so agents act on elements without coordinates. | 2026-09-08 |


### PR DESCRIPTION
## Summary

The Japanese and Simplified Chinese READMEs had drifted from `README.md`. Structure already matched (same headings, identical code blocks, env vars, tables), but some content was missing, and one link in zh-CN was broken. This PR also drops the issue #98 links from the docs.

### Fixed in both `README.ja.md` and `README.zh-CN.md`
- **Tool list:** add the missing `mobile_batch_commands` entry under Logs & Crash Reports.
- **Streamable HTTP Server Mode**, bringing both in line with the English section added in #441:
  - the "old pure-SSE flow on `/mcp` is no longer available" sentence in the migration note
  - the note that Host-header DNS rebinding protection is enabled automatically when binding to localhost
  - the "works well with Smithery and other horizontal hosts" clause

### Fixed in `README.zh-CN.md` only
- **Privacy policy link:** the URL was followed directly by a full-width `。`, and GitHub's autolinker put it inside the link (`https://mobilenext.ai/privacy%E3%80%82`), producing a broken link. It's now an explicit markdown link.

### Removed issue links
- The migration notes in all three READMEs and the Streamable HTTP row in `ROADMAP.md` no longer link to the GitHub issue.

## Verification
- All three READMEs are 577 lines. They have matching heading structure (37), identical code blocks (26), and identical sets of URLs (43), env vars (4) and tool names (32). No section differs in prose, list or quote line counts.
- No references to the issue remain in the READMEs, `ROADMAP.md` or `src/`.
- Rendered the zh-CN privacy paragraph through GitHub's markdown API: the link is now `https://mobilenext.ai/privacy`, with `。` outside it.

## Test plan
- [ ] Skim the rendered ja and zh-CN READMEs on this branch: tool list, Streamable HTTP section, privacy link
- [ ] Native-speaker pass on the new sentences (optional)
